### PR TITLE
Caches and nodes filtering + e2e tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,7 @@ dist
 .settings
 .project
 .classpath
+.idea
+infinispan-management-console.iml
 src/main/bower_components
 target

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ dist
 infinispan-management-console.iml
 src/main/bower_components
 target
+README.md~

--- a/AUTHORS
+++ b/AUTHORS
@@ -2,4 +2,5 @@ Martin Šošić
 Matija Šošić
 Tristan Tarrant
 Vladimir Blagojevic
+Tomáš Sýkora
 

--- a/README.md
+++ b/README.md
@@ -32,5 +32,5 @@
   - `echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p`
 
 - If you meet: "Error: ENOENT, stat /path/to/index.html" try following clears:
-  - `sudo npm cache clear` `gulp clean` `gulp clear-cache`
+  - `gulp clean` `gulp clear-cache`
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 - Install gulp globally (use sudo if needed): `npm install gulp -g`
 - run `build.sh` to instal local packages and client dependencies
 - NOTE: you will need to repeat the step above if there are some changes to package.json or bower.json
+- NOTE: you might want to consult Troubleshooting section of this README
 
 # Setting up the server (we need it for web application to fetch data, you do this only once)
 - you need JDK 7 or 8 and Maven
@@ -21,3 +22,15 @@
 - Run e2e tests on production code by running `gulp protractor:dist`
 - Run `gulp clean` to remove generated files like /dist/ and /.tmp/
 - Run `gulp clear-cache` to clean gulp cache
+
+#  Troubleshooting
+- If you meet: "Cannot find where you keep your Bower packages."
+  - Install bower globally (use sudo if needed): `npm install bower -g`
+  - run `bower install` from application root directory, it will install dependencies into ./src/main/bower_components
+
+- If you meet: "Error: watch ENOSPC"; try to increase number of watches:
+  - `echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p`
+
+- If you meet: "Error: ENOENT, stat /path/to/index.html" try following clears:
+  - `sudo npm cache clear` `gulp clean` `gulp clear-cache`
+

--- a/src/main/webapp/cluster-view/cluster-view.html
+++ b/src/main/webapp/cluster-view/cluster-view.html
@@ -111,7 +111,9 @@
             <!-- RIGHT COLUMN ROW #1 START -->
             <div class="row">
                 <div class="col-md-12" style="padding-top:20px; padding-bottom:20px;">
-                    <input type="search" class="search-field">
+                    <!-- filter according to cache or server name -->
+                    <input id="cacheOrNodeFilterQueryInput" ng-model="cacheOrNodeFilterQuery.name" type="search"
+                           class="search-field" placeholder="filter caches or nodes">
                     <div style="float:left;">
                         <span class="glyphicon glyphicon-th-large header-links-container" ng-class="{selected: shared.currentCollection == 'nodes'}">
               <a class="header-links" ng-click="shared.currentCollection = 'nodes'"> Nodes </a>
@@ -128,7 +130,7 @@
             <div class="row" style="padding-left:15px !important; margin: 0px important!;">
                 <div ng-show="shared.currentCollection == 'nodes'">
                     <div ng-show="!currentCluster.getNodes() || currentCluster.getNodes().length === 0">There are no nodes to show.</div>
-                    <div class="box col-md-2 nopadding" ng-repeat="node in currentCluster.getNodes()">
+                    <div class="box col-md-2 nopadding" ng-repeat="node in currentCluster.getNodes() | filter:cacheOrNodeFilterQuery">
                         <a class="text-center" ui-sref="nodeDetails({clusterName: currentCluster.name, nodeName: node.name})">
               {{node.name}} <br><br>
             </a>
@@ -137,10 +139,9 @@
 
                 <div ng-show="shared.currentCollection == 'caches'">
                     <div ng-show="!currentCluster.caches || currentCluster.caches.length === 0">There are no caches to show.</div>
-                    <div class="box col-md-2 nopadding" ng-repeat="cache in currentCluster.caches">
-                        <a ui-sref="cacheDetails({clusterName: currentCluster.name, cacheName: cache.name})">
-                            <h4>{{cache.name}}</h4> 
-
+                    <div class="box col-md-2 nopadding" ng-repeat="cache in currentCluster.caches | filter:cacheOrNodeFilterQuery">
+                           <a ui-sref="cacheDetails({clusterName: currentCluster.name, cacheName: cache.name})">
+                               <h4>{{cache.name}}</h4>
                             <br>
                         </a>
                     </div>

--- a/src/main/webapp/clusters-view/clusters-view.html
+++ b/src/main/webapp/clusters-view/clusters-view.html
@@ -8,7 +8,7 @@
             <div class="list-group">
                 <div class="list-group-item row" ng-repeat="cluster in clusters">
                     <div class="col-md-4">
-                        <a href="#/cluster/{{cluster.name}}"><h4>{{cluster.name}}</h4>
+                        <a href="#/cluster/{{cluster.name}}" id="cluster-link-{{cluster.name}}"><h4>{{cluster.name}}</h4>
                         <i class="fa fa-check-square fa-2x available"></i>  <span class="available">Available</span></a>
                     </div>
                     <div class="col-md-4">? Nodes

--- a/src/main/webapp/components/api/cluster-model.service.js
+++ b/src/main/webapp/components/api/cluster-model.service.js
@@ -12,7 +12,7 @@ angular.module('managementConsole.api')
                 this.domain = domain;
                 this.modelController = domain.getModelController();
                 this.lastRefresh = null;
-                this.caches = {};
+                this.caches = []; // desired to have caches in an array so we can filter out through their names
             };
 
             Cluster.prototype.getModelController = function () {
@@ -26,7 +26,7 @@ angular.module('managementConsole.api')
             Cluster.prototype.refresh = function () {
                 return this.modelController.readResource(this.getResourcePath(), false, false).then(function (response) {
                     this.lastRefresh = new Date();
-                    this.caches = {};
+                    this.caches = [];
                     var cachePromises = [];
                     var cacheTypes = ['local-cache', 'distributed-cache', 'replicated-cache', 'invalidation-cache'];
                     for (var i = 0; i < cacheTypes.length; i++) {
@@ -35,7 +35,7 @@ angular.module('managementConsole.api')
                             for (var name in typedCaches) {
                                 if (name !== undefined) {
                                     var cache = new CacheModel(name, cacheTypes[i], this);
-                                    this.caches[name] = cache;
+                                    this.caches.push(cache);
                                     cachePromises.push(cache.refresh());
                                 }
                             }

--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -74,7 +74,7 @@
     <script src="components/navbar/navbar.controller.js"></script>
  
     <!-- inject:partials -->
-    <!-- angular templates will be automaticaly converted in js and inserted here -->
+    <!-- angular templates will be automatically converted in js and inserted here -->
     <!-- endinject -->
     <!-- endbuild -->
 

--- a/src/main/webapp/login/login.html
+++ b/src/main/webapp/login/login.html
@@ -24,7 +24,7 @@
                     </div>
                     <div class="form-group">
                         <div class="col-sm-12 col-md-12 submit">
-                            <button type="submit" class="btn btn-primary btn-lg" tabindex="3">Log In</button>
+                            <button id="login-submit-button" type="submit" class="btn btn-primary btn-lg" tabindex="3">Log In</button>
                         </div>
                     </div>
                 </form>

--- a/src/test/e2e/cachesFilteringTest.js
+++ b/src/test/e2e/cachesFilteringTest.js
@@ -1,0 +1,37 @@
+'use strict';
+
+describe('Cache filtering', function () {
+
+  var utils = require('../e2eUtils');
+
+  beforeEach(function () {
+    utils.defaultLogin();
+    // 'http://localhost:3000/index.html#/cluster/clustered'
+    var link = element(by.id('cluster-link-clustered'));
+    link.click();
+  });
+
+  it('should find cacheOrNodeFilterQueryInput element on cluster/clustered page', function() {
+    expect(element(by.id('cacheOrNodeFilterQueryInput')).isPresent()).toBe(true);
+  });
+
+  it('should filter caches when user types cache name into filter input field', function () {
+    var linkToNodes = element(by.linkText('Caches'));
+    linkToNodes.click();
+    browser.sleep(300);
+
+    var cacheList = element.all(by.repeater('cache in currentCluster.caches | filter:cacheOrNodeFilterQuery'));
+    var query = element(by.model('cacheOrNodeFilterQuery.name'));
+
+    browser.sleep(1000);
+    expect(cacheList.count()).toBe(3);
+
+    query.sendKeys('default');
+
+    expect(cacheList.count()).toBe(1);
+    query.clear();
+    // memcachedCache + namedCache
+    query.sendKeys('cache');
+    expect(cacheList.count()).toBe(2);
+  });
+});

--- a/src/test/e2e/main.js
+++ b/src/test/e2e/main.js
@@ -1,15 +1,16 @@
 'use strict';
 
-describe('The main view', function () {
+describe('The main clusters view', function () {
+
+  var utils = require('../e2eUtils');
 
   beforeEach(function () {
-    browser.get('http://localhost:3000/index.html');
+    utils.defaultLogin();
+    // login page automatically redirects to #/clusters page, no action needed here
   });
 
-  it('list more than 5 awesome things', function () {
-    element.all(by.repeater('awesomeThing in awesomeThings')).count().then(function(count) {
-      expect(count > 5).toBeTruthy();
-    });
+  it('should contain 2 containers by default ', function () {
+    var clusters = element.all(by.repeater('cluster in clusters'));
+    expect(clusters.count()).toBe(2);
   });
-
 });

--- a/src/test/e2e/nodesFilteringTest.js
+++ b/src/test/e2e/nodesFilteringTest.js
@@ -1,0 +1,41 @@
+'use strict';
+
+describe('Node filtering', function () {
+
+  var utils = require('../e2eUtils');
+
+  beforeEach(function () {
+    utils.defaultLogin();
+    var link = element(by.id('cluster-link-clustered'));
+    link.click();
+  });
+
+  it('should find cacheOrNodeFilterQueryInput element on cluster/clustered page', function() {
+    expect(element(by.id('cacheOrNodeFilterQueryInput')).isPresent()).toBe(true);
+  });
+
+  it('should filter nodes when user types node name into filter input field', function () {
+    var linkToNodes = element(by.linkText('Nodes'));
+    linkToNodes.click();
+    browser.sleep(300);
+
+    var nodeList = element.all(by.repeater('node in currentCluster.getNodes() | filter:cacheOrNodeFilterQuery'));
+    var query = element(by.model('cacheOrNodeFilterQuery.name'));
+
+    browser.sleep(1000);
+    // master/server-one; master/server-two; master/server-three expected
+    expect(nodeList.count()).toBe(3);
+
+    query.sendKeys('one');
+    expect(nodeList.count()).toBe(1);
+    query.clear();
+
+    query.sendKeys('two');
+    expect(nodeList.count()).toBe(1);
+    query.clear();
+
+    query.sendKeys('/server');
+    expect(nodeList.count()).toBe(3);
+    query.clear();
+  });
+});

--- a/src/test/e2eUtils.js
+++ b/src/test/e2eUtils.js
@@ -1,0 +1,9 @@
+module.exports = {
+  defaultLogin: function () {
+    browser.get('http://localhost:3000/index.html#/login');
+    element(by.model('credentials.username')).sendKeys('admin');
+    element(by.model('credentials.password')).sendKeys('!qazxsw2');
+    element(by.id('login-submit-button')).click();
+    browser.sleep(500);
+  }
+};

--- a/src/test/protractor.conf.js
+++ b/src/test/protractor.conf.js
@@ -2,7 +2,7 @@
 exports.config = {
   // The address of a running selenium server.
   //seleniumAddress: 'http://localhost:4444/wd/hub',
-  seleniumServerJar: '../../node_modules/protractor/selenium/selenium-server-standalone-2.43.1.jar', // Make use you check the version in the folder
+  seleniumServerJar: '../../node_modules/protractor/selenium/selenium-server-standalone-2.44.0.jar', // Make use you check the version in the folder
 
   // Capabilities to be passed to the webdriver instance.
   capabilities: {


### PR DESCRIPTION
Christmas PullRequest!! :)

Hello guys,
I've implemented filtering for caches and nodes at particular cluster's page. Considering deployment, where there live more than 100 caches, that could be useful. 

Also I've added e2e protractor tests for all implemented behaviour. Working on my local machine, hope that also works for you (probably u need Chrome, so far) and also running Infinispan server (of course). 

Let me know if you spot something. 

Note: I had to change Cluster.caches (cluster-model-service.js) variable from an Object ({}) to an Array ([]) because filtering in AngularJS works only for arrays right now. There is an open issue for ng to make it work also for Objects. This shouldn't cause any problems for us now. It's just an array.    