### PR TITLE
Cluster cache availability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,7 @@ dist
 .settings
 .project
 .classpath
+.idea
+infinispan-management-console.iml
 src/main/bower_components
 target

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 dist
+.idea
 .tmp
 .sass-cache
 .settings

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ dist
 infinispan-management-console.iml
 src/main/bower_components
 target
+README.md~

--- a/AUTHORS
+++ b/AUTHORS
@@ -2,4 +2,5 @@ Martin Šošić
 Matija Šošić
 Tristan Tarrant
 Vladimir Blagojevic
+Tomáš Sýkora
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@
 - NOTE: you will need to repeat the step above if there are some changes to package.json or bower.json
 - NOTE: you might want to consult Troubleshooting section of this README
 
+# Windows specific installation
+
+- You can download respective node.js installer here: http://nodejs.org/download/
+- After installation set up user specific environment properties *NODE_PATH* and *PATH* pointing to the installation location
+  - needed for running gulp from command prompt -- typically: C:\Users\You\AppData\Roaming\npm
+
 # Setting up the server (we need it for web application to fetch data, you do this only once)
 - you need JDK 7 or 8 and Maven
 - from the top-level of infinispan ($ISPN_HOME) run: `./build.sh clean package -DskipTests`
@@ -32,5 +38,5 @@
   - `echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p`
 
 - If you meet: "Error: ENOENT, stat /path/to/index.html" try following clears:
-  - `sudo npm cache clear` `gulp clean` `gulp clear-cache`
+  - `gulp clean` `gulp clear-cache`
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 - Install gulp globally (use sudo if needed): `npm install gulp -g`
 - run `build.sh` to instal local packages and client dependencies
 - NOTE: you will need to repeat the step above if there are some changes to package.json or bower.json
+- NOTE: you might want to consult Troubleshooting section of this README
 
 # Setting up the server (we need it for web application to fetch data, you do this only once)
 - you need JDK 7 or 8 and Maven
@@ -21,3 +22,15 @@
 - Run e2e tests on production code by running `gulp protractor:dist`
 - Run `gulp clean` to remove generated files like /dist/ and /.tmp/
 - Run `gulp clear-cache` to clean gulp cache
+
+#  Troubleshooting
+- If you meet: "Cannot find where you keep your Bower packages."
+  - Install bower globally (use sudo if needed): `npm install bower -g`
+  - run `bower install` from application root directory, it will install dependencies into ./src/main/bower_components
+
+- If you meet: "Error: watch ENOSPC"; try to increase number of watches:
+  - `echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p`
+
+- If you meet: "Error: ENOENT, stat /path/to/index.html" try following clears:
+  - `sudo npm cache clear` `gulp clean` `gulp clear-cache`
+

--- a/src/main/webapp/cache-details/cache-details.controller.js
+++ b/src/main/webapp/cache-details/cache-details.controller.js
@@ -16,7 +16,7 @@ angular.module('managementConsole')
             var server = modelController.getServer();
             var clusters = server.getClusters();
             $scope.currentCluster = server.getCluster(clusters, $stateParams.clusterName);
-            $scope.caches = $scope.currentCluster.getCaches();
+            $scope.caches = $scope.currentCluster.getCachesNameMap();
             $scope.currentCache = $scope.caches[$stateParams.cacheName];
             $scope.currentCacheStats = {
                 'cache-status': '',

--- a/src/main/webapp/cluster-view/cluster-view.controller.js
+++ b/src/main/webapp/cluster-view/cluster-view.controller.js
@@ -16,6 +16,12 @@ angular.module('managementConsole')
             $scope.clusters = modelController.getServer().getClusters();
             $scope.currentCluster = modelController.getServer().getCluster($scope.clusters, $stateParams.clusterName);
 
+            $scope.serversCheckboxes = [];
+
+            $scope.currentCluster.getNodes().forEach(function(node) {
+                $scope.serversCheckboxes[node.server] = true;
+            });
+
             $scope.$watch('currentCluster', function (currentCluster) {
                 if (currentCluster && currentCluster.name !== $stateParams.clusterName) {
                     $state.go('clusterView', {

--- a/src/main/webapp/cluster-view/cluster-view.html
+++ b/src/main/webapp/cluster-view/cluster-view.html
@@ -41,13 +41,13 @@
 
     <!-- TOP ROW #2 START -->
     <div class="row">
-        <div class="col-md-2 text-center">
-           <div ng-show="currentCluster.clusterAvailability === 'AVAILABLE'">
-              <p class="fa fa-check-square fa-1x available"> {{currentCluster.clusterAvailability}} </p>
-           </div>
-           <div ng-show="currentCluster.clusterAvailability !== 'AVAILABLE'">
-              <p class="fa fa-times-circle fa-1x unavailable"> UNAVAILABLE </p>
-           </div>
+        <div class="col-md-2 text-left">
+            <div ng-show="currentCluster.availability === 'AVAILABLE'">
+                <p class="fa fa-1x available">AVAILABLE</p>
+            </div>
+            <div ng-show="currentCluster.availability !== 'AVAILABLE'">
+                <p class="fa fa-1x unavailable">UNAVAILABLE</p>
+            </div>
         </div>
         <div class="col-md-2 text-center">
             <span class="bigger-font"> {{currentCluster.caches.length || '?'}} </span>  <span class="smaller-font"> Caches</span>

--- a/src/main/webapp/cluster-view/cluster-view.html
+++ b/src/main/webapp/cluster-view/cluster-view.html
@@ -42,7 +42,12 @@
     <!-- TOP ROW #2 START -->
     <div class="row">
         <div class="col-md-2 text-center">
-            <h4 style="color:   #009A31;">Available</h4>
+           <div ng-show="currentCluster.clusterAvailability === 'AVAILABLE'">
+              <p class="fa fa-check-square fa-1x available"> {{currentCluster.clusterAvailability}} </p>
+           </div>
+           <div ng-show="currentCluster.clusterAvailability !== 'AVAILABLE'">
+              <p class="fa fa-times-circle fa-1x unavailable"> UNAVAILABLE </p>
+           </div>
         </div>
         <div class="col-md-2 text-center">
             <span class="bigger-font"> {{currentCluster.caches.length || '?'}} </span>  <span class="smaller-font"> Caches</span>
@@ -73,7 +78,8 @@
                         <span style="font-size:16px; font-weight: bold;"> Servers</span> 
                         <br>
                         <div ng-repeat="node in currentCluster.getNodes()">
-                            <input type="checkbox" value="checkbox" name="caches">{{node.name}}
+                            <input type="checkbox" ng-model="serversCheckboxes[node.server]"
+                                   name="serverCheckboxFor{{node.server}}">{{node.name}}
                             <br>
                         </div>
                     </div>
@@ -138,13 +144,36 @@
                 </div>
 
                 <div ng-show="shared.currentCollection == 'caches'">
-                    <div ng-show="!currentCluster.caches || currentCluster.caches.length === 0">There are no caches to show.</div>
-                    <div class="box col-md-2 nopadding" ng-repeat="cache in currentCluster.caches | filter:cacheOrNodeFilterQuery">
-                           <a ui-sref="cacheDetails({clusterName: currentCluster.name, cacheName: cache.name})">
-                               <h4>{{cache.name}}</h4>
-                            <br>
-                        </a>
-                    </div>
+
+                   <div class="box col-md-2 nopadding" ng-repeat="node in currentCluster.getNodes()">
+
+                         <div ng-show="!currentCluster.caches || currentCluster.caches.length === 0">There are no caches to show.</div>
+
+                            <div ng-show="serversCheckboxes[node.server]">
+
+                                 <h6>{{node.name}}</h6>
+
+                                 <div class="box col-md-2 nopadding"
+                                     ng-repeat="cache in currentCluster.getCachesByServerName(node.server) | filter:cacheOrNodeFilterQuery">
+
+                                       <a ui-sref="cacheDetails({clusterName: currentCluster.name, cacheName: cache.name})">
+                                          <h4>{{cache.name}}</h4>
+                                          <div ng-show="cache.cacheStatus === 'RUNNING'">
+                                             <p class="fa fa-check-square fa-1x available"></p> {{cache.cacheStatus}}
+                                          </div>
+                                          <div ng-show="cache.cacheStatus !== 'RUNNING'">
+                                             <p class="fa fa-times-circle fa-1x unavailable"></p> {{cache.cacheStatus}}
+                                          </div>
+                                          <div ng-show="cache.cacheAvailability === 'AVAILABLE'">
+                                             <p class="fa fa-check-square fa-1x available"></p> {{cache.cacheAvailability}}
+                                          </div>
+                                          <div ng-show="cache.cacheAvailability !== 'AVAILABLE'">
+                                             <p class="fa fa-times-circle fa-1x unavailable"></p> {{cache.cacheAvailability}}
+                                          </div>
+                                       </a>
+                                 </div>
+                            </div>
+                   </div>
                 </div>
             </div>
             <!-- RIGHT COLUMN ROW #2 END -->

--- a/src/main/webapp/cluster-view/cluster-view.html
+++ b/src/main/webapp/cluster-view/cluster-view.html
@@ -111,7 +111,9 @@
             <!-- RIGHT COLUMN ROW #1 START -->
             <div class="row">
                 <div class="col-md-12" style="padding-top:20px; padding-bottom:20px;">
-                    <input type="search" class="search-field">
+                    <!-- filter according to cache or server name -->
+                    <input id="cacheOrNodeFilterQueryInput" ng-model="cacheOrNodeFilterQuery.name" type="search"
+                           class="search-field" placeholder="filter caches or nodes">
                     <div style="float:left;">
                         <span class="glyphicon glyphicon-th-large header-links-container" ng-class="{selected: shared.currentCollection == 'nodes'}">
               <a class="header-links" ng-click="shared.currentCollection = 'nodes'"> Nodes </a>
@@ -128,7 +130,7 @@
             <div class="row" style="padding-left:15px !important; margin: 0px important!;">
                 <div ng-show="shared.currentCollection == 'nodes'">
                     <div ng-show="!currentCluster.getNodes() || currentCluster.getNodes().length === 0">There are no nodes to show.</div>
-                    <div class="box col-md-2 nopadding" ng-repeat="node in currentCluster.getNodes()">
+                    <div class="box col-md-2 nopadding" ng-repeat="node in currentCluster.getNodes() | filter:cacheOrNodeFilterQuery">
                         <a class="text-center" ui-sref="nodeDetails({clusterName: currentCluster.name, nodeName: node.name})">
               {{node.name}} <br><br>
             </a>
@@ -137,10 +139,9 @@
 
                 <div ng-show="shared.currentCollection == 'caches'">
                     <div ng-show="!currentCluster.caches || currentCluster.caches.length === 0">There are no caches to show.</div>
-                    <div class="box col-md-2 nopadding" ng-repeat="cache in currentCluster.caches">
-                        <a ui-sref="cacheDetails({clusterName: currentCluster.name, cacheName: cache.name})">
-                            <h4>{{cache.name}}</h4> 
-
+                    <div class="box col-md-2 nopadding" ng-repeat="cache in currentCluster.caches | filter:cacheOrNodeFilterQuery">
+                           <a ui-sref="cacheDetails({clusterName: currentCluster.name, cacheName: cache.name})">
+                               <h4>{{cache.name}}</h4>
                             <br>
                         </a>
                     </div>

--- a/src/main/webapp/clusters-view/clusters-view.html
+++ b/src/main/webapp/clusters-view/clusters-view.html
@@ -8,7 +8,7 @@
             <div class="list-group">
                 <div class="list-group-item row" ng-repeat="cluster in clusters">
                     <div class="col-md-4">
-                        <a href="#/cluster/{{cluster.name}}"><h4>{{cluster.name}}</h4>
+                        <a href="#/cluster/{{cluster.name}}" id="cluster-link-{{cluster.name}}"><h4>{{cluster.name}}</h4>
                         <i class="fa fa-check-square fa-2x available"></i>  <span class="available">Available</span></a>
                     </div>
                     <div class="col-md-4">? Nodes

--- a/src/main/webapp/clusters-view/clusters-view.html
+++ b/src/main/webapp/clusters-view/clusters-view.html
@@ -8,14 +8,14 @@
             <div class="list-group">
                 <div class="list-group-item row" ng-repeat="cluster in clusters">
                     <div class="col-md-4">
-                        <a href="#/cluster/{{cluster.name}}" id="cluster-link-{{cluster.name}}"><h4>{{cluster.name}}</h4>
-                           <div ng-show="cluster.clusterAvailability === 'AVAILABLE'">
-                              <p class="fa fa-check-square fa-1x available"> {{cluster.clusterAvailability}} </p>
-                           </div>
-                           <div ng-show="cluster.clusterAvailability !== 'AVAILABLE'">
-                              <p class="fa fa-times-circle fa-1x unavailable"> UNAVAILABLE </p>
-                           </div>
-                       </a>
+                        <a href="#/cluster/{{cluster.name}}"><h4>{{cluster.name}}</h4>
+                            <div ng-show="cluster.availability === 'AVAILABLE'">
+                                <p class="fa fa-check-square fa-1x available"> {{cluster.availability}} </p>
+                            </div>
+                            <div ng-show="cluster.availability !== 'AVAILABLE'">
+                                <p class="fa fa-times-circle fa-1x unavailable"> UNAVAILABLE </p>
+                            </div>
+                        </a>
                     </div>
                     <div class="col-md-4">? Nodes
                     </div>

--- a/src/main/webapp/clusters-view/clusters-view.html
+++ b/src/main/webapp/clusters-view/clusters-view.html
@@ -9,7 +9,13 @@
                 <div class="list-group-item row" ng-repeat="cluster in clusters">
                     <div class="col-md-4">
                         <a href="#/cluster/{{cluster.name}}" id="cluster-link-{{cluster.name}}"><h4>{{cluster.name}}</h4>
-                        <i class="fa fa-check-square fa-2x available"></i>  <span class="available">Available</span></a>
+                           <div ng-show="cluster.clusterAvailability === 'AVAILABLE'">
+                              <p class="fa fa-check-square fa-1x available"> {{cluster.clusterAvailability}} </p>
+                           </div>
+                           <div ng-show="cluster.clusterAvailability !== 'AVAILABLE'">
+                              <p class="fa fa-times-circle fa-1x unavailable"> UNAVAILABLE </p>
+                           </div>
+                       </a>
                     </div>
                     <div class="col-md-4">? Nodes
                     </div>

--- a/src/main/webapp/clusters-view/clusters-view.less
+++ b/src/main/webapp/clusters-view/clusters-view.less
@@ -1,3 +1,7 @@
 .available {
     color: green;
 }
+.unavailable {
+   color: red;
+}
+

--- a/src/main/webapp/components/api/cache-model.service.js
+++ b/src/main/webapp/components/api/cache-model.service.js
@@ -4,13 +4,17 @@ angular.module('managementConsole.api')
     .factory('CacheModel', [
 
     function () {
-            var Cache = function (name, type, cluster) {
+            var Cache = function (name, type, domain, cluster, serverName) {
                 this.name = name;
                 this.type = type;
                 this.cluster = cluster;
+                this.domain = domain;
+                this.serverName = serverName;
                 this.modelController = cluster.getModelController();
                 this.lastRefresh = null;
                 this.data = null;
+                this.cacheAvailability = this.refreshCacheAvailability();
+                this.cacheStatus = this.refreshCacheStatus();
             };
 
             Cache.prototype.getModelController = function () {
@@ -23,8 +27,30 @@ angular.module('managementConsole.api')
 
             Cache.prototype.refresh = function () {
                 return this.modelController.readResource(this.getResourcePath(), false, true).then(function (response) {
+                    this.refreshCacheAvailability();
+                    this.refreshCacheStatus();
                     this.data = response;
                     this.lastRefresh = new Date();
+                }.bind(this));
+            };
+
+            Cache.prototype.refreshCacheAvailability = function () {
+                this.domain.fetchCacheStatsForOneServer(this.serverName, this).then(function(response) {
+                    this.cacheAvailability = response['cache-availability'];
+                }.bind(this), function(error) {
+                    // TODO: hard-set here; are we able to read it somehow? When cache is terminated/stopped?
+                    this.cacheAvailability = 'UNAVAILABLE';
+                    console.log('Could not get cache status: ' + error);
+                }.bind(this));
+            };
+
+            Cache.prototype.refreshCacheStatus = function () {
+                this.domain.fetchCacheStatsForOneServer(this.serverName, this).then(function(response) {
+                    this.cacheStatus = response['cache-status'];
+                }.bind(this), function(error) {
+                    // TODO: hard-set here; are we able to read it somehow? When cache is terminated/stopped?
+                    this.cacheStatus = 'TERMINATED';
+                    console.log('Could not get cache status: ' + error);
                 }.bind(this));
             };
 

--- a/src/main/webapp/components/api/cluster-model.service.js
+++ b/src/main/webapp/components/api/cluster-model.service.js
@@ -14,6 +14,8 @@ angular.module('managementConsole.api')
                 this.lastRefresh = null;
                 this.caches = []; // desired to have caches in an array so we can filter out through their names
                 this.cachesNameMap = {}; // hashMap for fast Cache object referencing by cache name
+                this.cachesByServerName = {}; // serverName -> [caches]
+                this.clusterAvailability = this.refreshClusterAvailability();
             };
 
             Cluster.prototype.getModelController = function () {
@@ -26,28 +28,55 @@ angular.module('managementConsole.api')
 
             Cluster.prototype.refresh = function () {
                 return this.modelController.readResource(this.getResourcePath(), false, false).then(function (response) {
+                    this.refreshClusterAvailability();
                     this.lastRefresh = new Date();
                     this.caches = [];
                     var cachePromises = [];
-                    var cacheTypes = ['local-cache', 'distributed-cache', 'replicated-cache', 'invalidation-cache'];
-                    for (var i = 0; i < cacheTypes.length; i++) {
-                        var typedCaches = response[cacheTypes[i]];
-                        if (typedCaches !== undefined) {
-                            for (var name in typedCaches) {
-                                if (name !== undefined) {
-                                    var cache = new CacheModel(name, cacheTypes[i], this);
-                                    this.caches.push(cache);
-                                    this.cachesNameMap[name] = cache;
-                                    cachePromises.push(cache.refresh());
+                    var nodes = this.getNodes();
+
+                    for (var y = 0; y < nodes.length; y++) {
+                        var tmpCachesForOneServer = [];
+                        var cacheTypes = ['local-cache', 'distributed-cache', 'replicated-cache', 'invalidation-cache'];
+                        for (var i = 0; i < cacheTypes.length; i++) {
+                            var typedCaches = response[cacheTypes[i]];
+                            if (typedCaches !== undefined) {
+                                for (var name in typedCaches) {
+                                    if (name !== undefined) {
+
+                                        // TODO: All caches on all nodes. Do it on request?
+                                        // TODO: Possible bottleneck for big deployments!
+                                        var cache = new CacheModel(name, cacheTypes[i], this.domain, this, nodes[y].server);
+                                        this.caches.push(cache);
+                                        this.cachesNameMap[name] = cache;
+                                        tmpCachesForOneServer.push(cache);
+                                        cachePromises.push(cache.refresh());
+                                    }
                                 }
                             }
                         }
+
+                        this.cachesByServerName[nodes[y].server] = tmpCachesForOneServer;
+                        tmpCachesForOneServer = [];
                     }
                     return $q.all(cachePromises);
                 }.bind(this));
             };
 
-            Cluster.prototype.getAvailability = function () {};
+            Cluster.prototype.refreshClusterAvailability = function () {
+
+                // Temporary: we are checking cluster availability on the first server
+                // Question: is here any was how to check cluster availability globally?
+                var resourcePathCacheContainer = this.domain.getFistServerResourceRuntimePath()
+                        .concat('subsystem', 'infinispan', 'cache-container', this.name);
+
+                var promise = this.modelController.readAttribute(resourcePathCacheContainer, 'cluster-availability');
+                promise.then(function(response) {
+                    this.clusterAvailability = response;
+                }.bind(this),
+                function(error) {
+                    console.log('Could not get cluster availability: ' + error);
+                }.bind(this));
+            };
 
             Cluster.prototype.getNodes = function () {
                 return this.domain.getNodes();
@@ -65,6 +94,10 @@ angular.module('managementConsole.api')
              */
             Cluster.prototype.getCachesNameMap = function () {
                 return this.cachesNameMap;
+            };
+
+            Cluster.prototype.getCachesByServerName = function (serverName) {
+                return this.cachesByServerName[serverName];
             };
 
             return Cluster;

--- a/src/main/webapp/components/api/domain-model.service.js
+++ b/src/main/webapp/components/api/domain-model.service.js
@@ -116,7 +116,7 @@ angular.module('managementConsole.api')
                 if (server.isRunning()) {
                     var serverGroup = this.serverGroups[server.group];
                     var serverProfile = this.profiles[serverGroup.profile];
-                    var caches = cluster.getCaches();
+                    var caches = cluster.getCachesNameMap();
                     for (var name in caches) {
                         var cache = caches[name];
                         promises.push(server.fetchCacheStats(cache));

--- a/src/main/webapp/components/api/domain-model.service.js
+++ b/src/main/webapp/components/api/domain-model.service.js
@@ -16,6 +16,7 @@ angular.module('managementConsole.api')
                 this.serverGroups = {};
                 this.profiles = {};
                 this.servers = [];
+                this.serversNameMap = {}; // hashMap for Server object referencing by server name (e.g.: 'server-one')
             };
 
             Domain.prototype.getModelController = function () {
@@ -24,6 +25,10 @@ angular.module('managementConsole.api')
 
             Domain.prototype.getResourcePath = function () {
                 return [];
+            };
+
+            Domain.prototype.getFistServerResourceRuntimePath = function () {
+                return this.servers[0].getResourcePath();
             };
 
             Domain.prototype.refresh = function () {
@@ -61,6 +66,7 @@ angular.module('managementConsole.api')
                                 if (serverName !== undefined) {
                                     var server = new ServerModel(hostName, serverName, host.server[serverName]['server-group'], this);
                                     this.servers.push(server);
+                                    this.serversNameMap[serverName] = server;
                                     serverPromises.push(server.refresh());
                                 }
                             }
@@ -93,6 +99,14 @@ angular.module('managementConsole.api')
 
             Domain.prototype.getNodes = function () {
                 return this.servers;
+            };
+
+            Domain.prototype.getServersNameMap = function () {
+                return this.serversNameMap;
+            };
+
+            Domain.prototype.fetchCacheStatsForOneServer = function(serverName, cache) {
+                return this.serversNameMap[serverName].fetchCacheStats(cache);
             };
         
             Domain.prototype.fetchCacheStats = function(cluster, cache) {

--- a/src/main/webapp/components/api/domain-model.service.js
+++ b/src/main/webapp/components/api/domain-model.service.js
@@ -27,7 +27,7 @@ angular.module('managementConsole.api')
                 return [];
             };
 
-            Domain.prototype.getFistServerResourceRuntimePath = function () {
+            Domain.prototype.getFirstServerResourceRuntimePath = function () {
                 return this.servers[0].getResourcePath();
             };
 
@@ -108,7 +108,7 @@ angular.module('managementConsole.api')
             Domain.prototype.fetchCacheStatsForOneServer = function(serverName, cache) {
                 return this.serversNameMap[serverName].fetchCacheStats(cache);
             };
-        
+
             Domain.prototype.fetchCacheStats = function(cluster, cache) {
                 var promises = [];
                 for(var i=0; i<this.servers.length; i++) {

--- a/src/main/webapp/components/api/model-controller.service.js
+++ b/src/main/webapp/components/api/model-controller.service.js
@@ -90,6 +90,13 @@ angular.module('managementConsole.api')
                             deferred.reject();
                         }
                     }
+
+                    if (http.readyState === 4 && http.status === 500) {
+                        var error = http.responseText;
+                        // passing error further for particular use-case based handling
+                        // TODO: or do we want some global error handling here?
+                        deferred.reject(error);
+                    }
                 };
                 http.send(JSON.stringify(op));
                 return deferred.promise;

--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -74,7 +74,7 @@
     <script src="components/navbar/navbar.controller.js"></script>
  
     <!-- inject:partials -->
-    <!-- angular templates will be automaticaly converted in js and inserted here -->
+    <!-- angular templates will be automatically converted in js and inserted here -->
     <!-- endinject -->
     <!-- endbuild -->
 

--- a/src/main/webapp/login/login.html
+++ b/src/main/webapp/login/login.html
@@ -24,7 +24,7 @@
                     </div>
                     <div class="form-group">
                         <div class="col-sm-12 col-md-12 submit">
-                            <button type="submit" class="btn btn-primary btn-lg" tabindex="3">Log In</button>
+                            <button id="login-submit-button" type="submit" class="btn btn-primary btn-lg" tabindex="3">Log In</button>
                         </div>
                     </div>
                 </form>

--- a/src/test/e2e/cachesFilteringTest.js
+++ b/src/test/e2e/cachesFilteringTest.js
@@ -1,0 +1,37 @@
+'use strict';
+
+describe('Cache filtering', function () {
+
+  var utils = require('../e2eUtils');
+
+  beforeEach(function () {
+    utils.defaultLogin();
+    // 'http://localhost:3000/index.html#/cluster/clustered'
+    var link = element(by.id('cluster-link-clustered'));
+    link.click();
+  });
+
+  it('should find cacheOrNodeFilterQueryInput element on cluster/clustered page', function() {
+    expect(element(by.id('cacheOrNodeFilterQueryInput')).isPresent()).toBe(true);
+  });
+
+  it('should filter caches when user types cache name into filter input field', function () {
+    var linkToNodes = element(by.linkText('Caches'));
+    linkToNodes.click();
+    browser.sleep(300);
+
+    var cacheList = element.all(by.repeater('cache in currentCluster.caches | filter:cacheOrNodeFilterQuery'));
+    var query = element(by.model('cacheOrNodeFilterQuery.name'));
+
+    browser.sleep(1000);
+    expect(cacheList.count()).toBe(3);
+
+    query.sendKeys('default');
+
+    expect(cacheList.count()).toBe(1);
+    query.clear();
+    // memcachedCache + namedCache
+    query.sendKeys('cache');
+    expect(cacheList.count()).toBe(2);
+  });
+});

--- a/src/test/e2e/main.js
+++ b/src/test/e2e/main.js
@@ -1,15 +1,16 @@
 'use strict';
 
-describe('The main view', function () {
+describe('The main clusters view', function () {
+
+  var utils = require('../e2eUtils');
 
   beforeEach(function () {
-    browser.get('http://localhost:3000/index.html');
+    utils.defaultLogin();
+    // login page automatically redirects to #/clusters page, no action needed here
   });
 
-  it('list more than 5 awesome things', function () {
-    element.all(by.repeater('awesomeThing in awesomeThings')).count().then(function(count) {
-      expect(count > 5).toBeTruthy();
-    });
+  it('should contain 2 containers by default ', function () {
+    var clusters = element.all(by.repeater('cluster in clusters'));
+    expect(clusters.count()).toBe(2);
   });
-
 });

--- a/src/test/e2e/nodesFilteringTest.js
+++ b/src/test/e2e/nodesFilteringTest.js
@@ -1,0 +1,41 @@
+'use strict';
+
+describe('Node filtering', function () {
+
+  var utils = require('../e2eUtils');
+
+  beforeEach(function () {
+    utils.defaultLogin();
+    var link = element(by.id('cluster-link-clustered'));
+    link.click();
+  });
+
+  it('should find cacheOrNodeFilterQueryInput element on cluster/clustered page', function() {
+    expect(element(by.id('cacheOrNodeFilterQueryInput')).isPresent()).toBe(true);
+  });
+
+  it('should filter nodes when user types node name into filter input field', function () {
+    var linkToNodes = element(by.linkText('Nodes'));
+    linkToNodes.click();
+    browser.sleep(300);
+
+    var nodeList = element.all(by.repeater('node in currentCluster.getNodes() | filter:cacheOrNodeFilterQuery'));
+    var query = element(by.model('cacheOrNodeFilterQuery.name'));
+
+    browser.sleep(1000);
+    // master/server-one; master/server-two; master/server-three expected
+    expect(nodeList.count()).toBe(3);
+
+    query.sendKeys('one');
+    expect(nodeList.count()).toBe(1);
+    query.clear();
+
+    query.sendKeys('two');
+    expect(nodeList.count()).toBe(1);
+    query.clear();
+
+    query.sendKeys('/server');
+    expect(nodeList.count()).toBe(3);
+    query.clear();
+  });
+});

--- a/src/test/e2eUtils.js
+++ b/src/test/e2eUtils.js
@@ -1,0 +1,9 @@
+module.exports = {
+  defaultLogin: function () {
+    browser.get('http://localhost:3000/index.html#/login');
+    element(by.model('credentials.username')).sendKeys('admin');
+    element(by.model('credentials.password')).sendKeys('!qazxsw2');
+    element(by.id('login-submit-button')).click();
+    browser.sleep(500);
+  }
+};

--- a/src/test/protractor.conf.js
+++ b/src/test/protractor.conf.js
@@ -2,7 +2,7 @@
 exports.config = {
   // The address of a running selenium server.
   //seleniumAddress: 'http://localhost:4444/wd/hub',
-  seleniumServerJar: '../../node_modules/protractor/selenium/selenium-server-standalone-2.43.1.jar', // Make use you check the version in the folder
+  seleniumServerJar: '../../node_modules/protractor/selenium/selenium-server-standalone-2.44.0.jar', // Make use you check the version in the folder
 
   // Capabilities to be passed to the webdriver instance.
   capabilities: {


### PR DESCRIPTION
New features

* improved README a bit (from previous PR)
* added improvements for caches/nodes filter on cluster page (from previous PR)

* now we are really checking for cluster and cache availability 
  -- slight design change for needed as it is possible to have default cache running on server-one but terminated on server-two. I decided to show all caches in the cluster (organized under the server where they belongs to)
  -- didn't find better way to check cluster availability than taking the first server and check for cluster availability under e.g.: /host=master/server=server-one/subsystem=infinispan/cache-container=clustered

* reorganized cache view on cluster page (there are columns for each server)
  -- columns can be disabled/enabled by checking checkboxes in left upper corner of side menu