### PR TITLE
Adjust resource naming scheme to Infinispan 8.0

### DIFF
--- a/src/main/gulp/build.js
+++ b/src/main/gulp/build.js
@@ -50,9 +50,9 @@ pipes.copyBower = function (){
     .pipe(gulp.dest(paths.distDevBower));
 };
 
-pipes.buildScripts = function(srcPath, destPath) {
-  srcPath = srcPath || paths.scripts;
-  destPath = destPath || paths.distDev;
+pipes.buildScripts = function() {
+  var srcPath = paths.scripts;
+  var destPath = paths.distDev;
 
   return gulp.src(srcPath)
     .pipe(plugins.jshint())
@@ -61,9 +61,9 @@ pipes.buildScripts = function(srcPath, destPath) {
     .pipe(plugins.size());
 };
 
-pipes.buildPartials = function(srcPath, destPath) {
-  srcPath = srcPath || paths.partials;
-  destPath = destPath || paths.distDev;
+pipes.buildPartials = function() {
+  var srcPath = paths.partials;
+  var destPath = paths.distDev;
 
   return gulp.src(srcPath)
     .pipe(gulp.dest(destPath))

--- a/src/main/webapp/components/api/cluster-model.service.js
+++ b/src/main/webapp/components/api/cluster-model.service.js
@@ -22,7 +22,7 @@ angular.module('managementConsole.api')
             };
 
             Cluster.prototype.getResourcePath = function () {
-                return this.path.concat('subsystem', 'infinispan', 'cache-container', this.name);
+                return this.path.concat('subsystem', 'datagrid-infinispan', 'cache-container', this.name);
             };
 
             Cluster.prototype.refresh = function () {
@@ -52,7 +52,7 @@ angular.module('managementConsole.api')
               // We are checking cluster availability on the first server
               // Is here any was how to check cluster availability globally?
               var resourcePathCacheContainer = this.domain.getFistServerResourceRuntimePath()
-                .concat('subsystem', 'infinispan', 'cache-container', this.name);
+                .concat('subsystem', 'datagrid-infinispan', 'cache-container', this.name);
 
               return this.modelController.readAttribute(resourcePathCacheContainer, 'cluster-availability').then(function (response){
                 this.availability = response.toUpperCase();

--- a/src/main/webapp/components/api/domain-model.service.js
+++ b/src/main/webapp/components/api/domain-model.service.js
@@ -56,7 +56,7 @@ angular.module('managementConsole.api')
                 promises.push(profilePromise);
 
                 this.servers = [];
-                var hostsPromise = this.modelController.readChildrenResources(this.getResourcePath(), 'host', 1, true, false).then(function (response) {
+                var hostsPromise = this.modelController.readChildrenResources(this.getResourcePath(), 'host', 2, true, false).then(function (response) {
                     var serverPromises = [];
                     for (var hostName in response) {
                         if (hostName !== undefined) {

--- a/src/main/webapp/components/api/profile-model.service.js
+++ b/src/main/webapp/components/api/profile-model.service.js
@@ -29,8 +29,8 @@ angular.module('managementConsole.api')
                     this.lastRefresh = new Date();
                     var allClusters = {};
                     var clusterPromises = [];
-                    if (response.subsystem !== undefined && response.subsystem.infinispan !== undefined) {
-                        for (var name in response.subsystem.infinispan['cache-container']) {
+                    if (response.subsystem !== undefined && response.subsystem['datagrid-infinispan'] !== undefined) {
+                        for (var name in response.subsystem['datagrid-infinispan']['cache-container']) {
                             if (name !== undefined && !(name in allClusters)) {
                                 allClusters[name] = new ClusterModel(name, this.name, this.getResourcePath(), this.domain);
                             }
@@ -45,7 +45,7 @@ angular.module('managementConsole.api')
                     return $q.all(clusterPromises);
                 }.bind(this));
             };
-        
+
             Profile.prototype.getClusters = function() {
                 return this.clusters;
             };

--- a/src/main/webapp/components/api/server-model.service.js
+++ b/src/main/webapp/components/api/server-model.service.js
@@ -34,7 +34,7 @@ angular.module('managementConsole.api')
 
             Server.prototype.fetchCacheStats = function(cache) {
                 return this.getModelController()
-                    .readResource(this.getResourcePath().concat('subsystem', 'infinispan', 'cache-container', cache.cluster.name, cache.type, cache.name),
+                    .readResource(this.getResourcePath().concat('subsystem', 'datagrid-infinispan', 'cache-container', cache.cluster.name, cache.type, cache.name),
                                   false, true).then(function (response) {
                     response['node-name'] = this.name;
                     response['cache'] = this;
@@ -44,7 +44,7 @@ angular.module('managementConsole.api')
 
             Server.prototype.fetchAggregateNodeStats = function (cluster) {
               return this.getModelController()
-                .readResource(this.getResourcePath().concat('subsystem', 'infinispan', 'cache-container', cluster.name),
+                .readResource(this.getResourcePath().concat('subsystem', 'datagrid-infinispan', 'cache-container', cluster.name),
                 false, true).then(function (response) {
                   return response;
                 }.bind(this));


### PR DESCRIPTION
Also included is a small gulp fix so that changes to JS and HTML while node server is running are immediately deployed. This part of the build did not work. 