### PR TITLE
ISPN-5986 Avoid Nexus staging during the release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,20 +63,25 @@
    </ciManagement>
    <distributionManagement>
       <repository>
-         <id>jboss-releases-repository</id>
+         <id>${jboss.releases.repo.id}</id>
          <name>JBoss Release Repository</name>
          <url>${jboss.releases.repo.url}</url>
       </repository>
       <snapshotRepository>
-         <id>jboss-snapshots-repository</id>
+         <id>${jboss.snapshots.repo.id}</id>
          <name>JBoss Snapshot Repository</name>
          <url>${jboss.snapshots.repo.url}</url>
       </snapshotRepository>
    </distributionManagement>
-   
+
    <properties>
+      <!-- nexus-staging-maven-plugin -->
+      <autoReleaseAfterClose>true</autoReleaseAfterClose>
+
+      <jboss.releases.repo.id>jboss-releases-repository</jboss.releases.repo.id>
       <jboss.releases.repo.url>https://repository.jboss.org/nexus/service/local/staging/deploy/maven2/</jboss.releases.repo.url>
-      <jboss.snapshots.repo.url>https://repository.jboss.org/nexus/content/repositories/snapshots/</jboss.snapshots.repo.url>
+     <jboss.snapshots.repo.id>jboss-snapshots-repository</jboss.snapshots.repo.id>
+     <jboss.snapshots.repo.url>https://repository.jboss.org/nexus/content/repositories/snapshots/</jboss.snapshots.repo.url>
    </properties>
 
    <build>
@@ -156,7 +161,17 @@
                <classesDirectory>dist</classesDirectory>
             </configuration>
          </plugin>
+         <plugin>
+            <groupId>org.sonatype.plugins</groupId>
+            <artifactId>nexus-staging-maven-plugin</artifactId>
+            <version>1.6.6</version>
+            <extensions>true</extensions>
+            <configuration>
+               <!-- See configuration details at http://books.sonatype.com/nexus-book/reference/staging-deployment.html -->
+               <nexusUrl>${jboss.releases.repo.url}</nexusUrl>
+               <serverId>${jboss.releases.repo.id}</serverId>
+            </configuration>
+         </plugin>
       </plugins>
    </build>
 </project>
-


### PR DESCRIPTION
This change allows to skip Nexus Staging Process.

Unfortunately the first test round will be on the release date. So far I've tested it using custom Nexus instance and I also tested snapshot releases (they are not affected).

https://issues.jboss.org/browse/ISPN-5986