### PR TITLE
ISPN-6110 - memory values should be in GB not in bytes

### DIFF
--- a/src/main/webapp/node-status/node-status.html
+++ b/src/main/webapp/node-status/node-status.html
@@ -139,7 +139,7 @@
                   </tr>
                   <tr>
                     <th>Memory</th>
-                    <td id="directBufferPoolMemoryUsed">{{directBufferPoolMemoryUsed}} bytes</td>
+                    <td id="directBufferPoolMemoryUsed">{{(directBufferPoolMemoryUsed/1024/1024)|number}} MB</td>
                   </tr>
                 </table>
                 <h4>Mapped Buffers</h4>
@@ -150,7 +150,7 @@
                   </tr>
                   <tr>
                     <th>Memory</th>
-                    <td id="mappedBufferPoolMemoryUsed">{{mappedBufferPoolMemoryUsed}} bytes</td>
+                    <td id="mappedBufferPoolMemoryUsed">{{(mappedBufferPoolMemoryUsed/1024/1024)|number}} MB</td>
                   </tr>
                 </table>
               </div>


### PR DESCRIPTION
Master only. Use MB instead of bytes. I chose MB overGB because the values I've seen were rather small for GBs and issue reporter suggested we can use MB as well. 