### PR TITLE
Remove status filters from cluster view

### DIFF
--- a/src/main/webapp/cluster-view/cluster-view.html
+++ b/src/main/webapp/cluster-view/cluster-view.html
@@ -194,6 +194,7 @@
             </div>
           </div>
         </div>
+        <!--- Removed until we develop DMR structure for these
         <div class="panel panel-default">
           <div class="panel-heading">
             <h4 class="panel-title">
@@ -213,7 +214,7 @@
               </fieldset>
             </div>
           </div>
-        </div>
+        </div>----->
       </div>
     </div>
   </div>


### PR DESCRIPTION
Not a resolution for https://issues.jboss.org/browse/ISPN-5916 but as we are postponing the fix - we should at least remove these filters as they are not working atm