### PR TITLE
Introduce memory chart directive

### DIFF
--- a/src/ManagementConsole.ts
+++ b/src/ManagementConsole.ts
@@ -33,6 +33,7 @@ import IAngularEvent = angular.IAngularEvent;
 import {FileModelDirective} from "./components/directives/FileModelDirective";
 import {VertilizeContainerDirective} from "./components/directives/VertilizeContainerDirective";
 import {VertilizeDirective} from "./components/directives/VertilizeDirective";
+import {MemoryDirective} from "./components/directives/memory/MemoryDirective";
 
 const App: ng.IAngularStatic = angular;
 
@@ -54,6 +55,7 @@ module.config(($translateProvider: ITranslateProvider) => {
 module.directive("fileModel", FileModelDirective.factory());
 module.directive("vertilizeContainer", VertilizeContainerDirective.factory());
 module.directive("vertilize", VertilizeDirective.factory());
+module.directive("memoryChart", MemoryDirective.factory());
 
 // @ngInject
 module.config(($urlRouterProvider: ng.ui.IUrlRouterProvider) => {

--- a/src/components/directives/memory/MemoryChart.ts
+++ b/src/components/directives/memory/MemoryChart.ts
@@ -1,0 +1,43 @@
+/// <reference path="../../../../typings/globals/d3/index.d.ts" />
+/// <reference path="../../../../typings/globals/c3/index.d.ts" />
+
+import * as c3 from "c3";
+import {MemoryData} from "../../memory/MemoryData";
+
+export class MemoryChart {
+  chart: c3.ChartAPI;
+
+  constructor(bindTo: string, private data: MemoryData) {
+    this.chart = c3.generate({
+      bindto: bindTo,
+      size: {
+        width: 220,
+        height: 220
+      },
+      data: {
+        columns: [
+          ["JVM", this.data.getUsedJVM()],
+          ["Off-heap", this.data.getUsedOffHeap()],
+          ["Free", this.data.getTotalUsedMemory()]
+        ],
+        type: "donut"
+      },
+      donut: {
+        title: "" + this.data.getTotalMemory() + " GB"
+      }
+    });
+  }
+
+  public getMemoryData(): MemoryData {
+    return this.data;
+  }
+
+  redraw(): void {
+    this.chart.flush();
+  }
+
+  destroy(): void {
+    this.chart.destroy();
+  }
+}
+

--- a/src/components/directives/memory/MemoryDirective.ts
+++ b/src/components/directives/memory/MemoryDirective.ts
@@ -1,0 +1,42 @@
+import IAugmentedJQuery = angular.IAugmentedJQuery;
+import IAttributes = angular.IAttributes;
+import IDirective = angular.IDirective;
+import IDirectiveFactory = angular.IDirectiveFactory;
+import {MemoryChart} from "./MemoryChart";
+import {MemoryData} from "../../memory/MemoryData";
+
+export interface IMemoryScope extends ng.IScope {
+  data: MemoryData;
+  chartId: string;
+  title: string;
+}
+
+export class MemoryDirective implements IDirective {
+  static $inject: string[] = ["$parse"];
+
+  public templateUrl: string = "components/directives/memory/view/memory.html";
+  public restrict: string = "E";
+  public scope: {[key: string]: string} = {
+    "data": "=",
+    "chartId": "@",
+    "title": "@"
+  };
+  public controller: Function = MemoryDirective;
+
+  public static factory(): IDirectiveFactory {
+    let directive: IDirectiveFactory = () => {
+      return new MemoryDirective();
+    };
+    return directive;
+  }
+
+  public link: Function = (scope: IMemoryScope, element: IAugmentedJQuery, attrs: IAttributes) => {
+    scope.$watch("data", (newVal) => {
+      if (newVal) {
+        let chart: MemoryChart = new MemoryChart("#" + scope.chartId, scope.data);
+        chart.redraw();
+      }
+    }, true);
+  };
+}
+

--- a/src/components/directives/memory/view/memory.html
+++ b/src/components/directives/memory/view/memory.html
@@ -1,0 +1,34 @@
+<div class="card-pf card-pf-accented ispn-card" vertilize>
+  <div class="card-pf-heading">
+    <h2 class="card-pf-title">{{title}}</h2>
+  </div>
+  <div class="card-pf-body">
+    <div class="row">
+      <div>
+        <div id="{{chartId}}"></div>
+      </div>
+      <div ng-if="!data">
+        <h4>No data available</h4>
+      </div>
+    </div>
+    <div class="row" style="padding: 5px">
+      <table class="col-sm-12 col-xs-12 col-md-12 table">
+        <tr>
+          <th>&nbsp;</th>
+          <th class="small" style="text-align: center"><strong>JVM</strong></th>
+          <th class="small" style="text-align: center"><strong>OFF HEAP</strong></th>
+        </tr>
+        <tr>
+          <th style="text-align: center"><strong>MAX</strong></th>
+          <td class="small" style="text-align: center">{{data.getMaxJVM()}} GB</td>
+          <td class="small" style="text-align: center">{{data.getMaxOffHeap()}} GB</td>
+        </tr>
+        <tr>
+          <th style="text-align: center"><strong>USED</strong></th>
+          <td class="small" style="text-align: center">{{data.getUsedJVM()}} GB</td>
+          <td class="small" style="text-align: center">{{data.getUsedOffHeap()}} GB</td>
+        </tr>
+      </table>
+    </div>
+  </div>
+</div>

--- a/src/components/memory/MemoryData.ts
+++ b/src/components/memory/MemoryData.ts
@@ -1,0 +1,40 @@
+export class MemoryData {
+
+  constructor(private usedJVM: number,
+              private maxJVM: number,
+              private usedOffHeap: number,
+              private maxOffHeap: number) {
+  }
+
+  public getUsedJVM(): number {
+    // convert to GB
+    return this.usedJVM;
+  }
+
+  public getUsedOffHeap(): number {
+    // convert to GB
+    return this.usedOffHeap;
+  }
+
+  public getMaxJVM(): number {
+    // convert to GB
+    return this.maxJVM;
+  }
+
+  public getMaxOffHeap(): number {
+    // convert to GB
+    return this.maxOffHeap;
+  }
+
+  public getTotalMemory(): number {
+    return this.getMaxJVM() + this.getMaxOffHeap();
+  }
+
+  public getTotalUsedMemory(): number {
+    return this.getUsedJVM() + this.getUsedOffHeap();
+  }
+
+  public getTotalFreeMemory(): number {
+    return this.getTotalMemory() - this.getTotalUsedMemory();
+  }
+}


### PR DESCRIPTION
@ryanemerson we will use memory chart directive in cache, server instance, and new memory usage tab. _Do not_ integrate as is. See how it works, check it out and when we are ready we will remove the topmost commit that uses memory chart directive to draw memory chart on server instance page. 
