### PR TITLE
Disable minification on upstream.

### DIFF
--- a/tasks/build-dist.js
+++ b/tasks/build-dist.js
@@ -23,7 +23,7 @@ module.exports = (gulp, config) => () => {
     const moduleName = config.moduleName;
     const buildConfig = {
       format: 'global',
-      minify: true,
+      minify: false,
       sourceMaps: true
     };
     return builder.buildStatic(moduleName, outFile, buildConfig);


### PR DESCRIPTION
We need to disable minification on upstream so that the console works on the next upstream release of Infinispan.