### PR TITLE
ISPN-7236 management of remote sites is not working

### DIFF
--- a/src/module/cache-container/SiteManagementModalCtrl.ts
+++ b/src/module/cache-container/SiteManagementModalCtrl.ts
@@ -45,7 +45,7 @@ export class SiteManagementModalCtrl {
       );
   }
 
-  executeSiteOperation(operation: string, siteName: string, message: string): void {
+  executeSiteOperation(siteName: string, operation: string, message: string): void {
     let modal: IModalServiceInstance = openConfirmationModal(this.$uibModal, message);
 
     modal.result.then(() => {

--- a/src/module/cache-container/caches/view/caches.html
+++ b/src/module/cache-container/caches/view/caches.html
@@ -53,11 +53,11 @@
                   </span>
             </p>
             <p ng-if="cache.hasRemoteBackup()" style="height:20px" ng-init="container = ctrl.container">
-                <span ng-repeat="site in container['sites-offline'][cache.name]"><span
+                <span ng-repeat="site in container['sites-offline']"><span
                   class="pficon pficon-error-circle-o"></span> {{site}} &nbsp;</span>
-              <span ng-repeat="site in container['sites-mixed'][cache.name]"><span
+              <span ng-repeat="site in container['sites-mixed']"><span
                 class="pficon pficon-warning-triangle-o"></span> {{site}} &nbsp;</span>
-              <span ng-repeat="site in container['sites-online'][cache.name]"><span class="pficon pficon-ok"></span> {{site}} &nbsp;</span>
+              <span ng-repeat="site in container['sites-online']"><span class="pficon pficon-ok"></span> {{site}} &nbsp;</span>
             </p>
           </div>
         </div>


### PR DESCRIPTION
Master only. We switched parameters somehow - that's why remote sites management fails. @ryanemerson please see my effort to display backup sites. The data structure has changed and container sites (online|offline|mixed) does not contain cache names as the previous code assumes. 