### PR TITLE
ISPN-7247 Changing any cache configuration adds security tag to the

### DIFF
--- a/src/components/cache-security/CacheSecurityCtrl.ts
+++ b/src/components/cache-security/CacheSecurityCtrl.ts
@@ -24,7 +24,7 @@ export class CacheSecurityCtrl implements IConfigurationCallback {
       this.configCallbacks.push(this);
     }
 
-    if (isNullOrUndefined(this.data)) {
+    if (this.isSecurityDefinedForContainer() && isNullOrUndefined(this.data)) {
       this.data = {
         "is-new-node": true,
         roles: []


### PR DESCRIPTION
Master only. Please verify the fix and the reasoning behind this particular solution. More details at https://issues.jboss.org/browse/ISPN-7247