### PR TITLE
ISPN-7247: Administration console - changing any cache configuration …

### DIFF
--- a/src/components/cache-configuration/view/distributed-cache.html
+++ b/src/components/cache-configuration/view/distributed-cache.html
@@ -45,7 +45,7 @@
     </uib-tab>
 
     <uib-tab heading="Security">
-      <cache-security container="$ctrl.container" data="$ctrl.data.security.SECURITY.authorization.AUTHORIZATION"
+      <cache-security container="$ctrl.container" data="$ctrl.data.security.SECURITY"
                       meta="$ctrl.getMetaForResource('authorization')"
                       init-defaults="$ctrl.initDefaults" read-only="$ctrl.readOnly"
                       config-callbacks="$ctrl.configCallbacks"/>

--- a/src/components/cache-configuration/view/invalidation-cache.html
+++ b/src/components/cache-configuration/view/invalidation-cache.html
@@ -45,7 +45,7 @@
         </uib-tab>
 
         <uib-tab heading="Security">
-            <cache-security container="$ctrl.container" data="$ctrl.data.security.SECURITY.authorization.AUTHORIZATION"
+            <cache-security container="$ctrl.container" data="$ctrl.data.security.SECURITY"
                             meta="$ctrl.getMetaForResource('authorization')"
                             init-defaults="$ctrl.initDefaults" read-only="$ctrl.readOnly"
                             config-callbacks="$ctrl.configCallbacks"/>

--- a/src/components/cache-configuration/view/local-cache.html
+++ b/src/components/cache-configuration/view/local-cache.html
@@ -44,7 +44,7 @@
         </uib-tab>
 
         <uib-tab heading="Security">
-            <cache-security container="$ctrl.container" data="$ctrl.data.security.SECURITY.authorization.AUTHORIZATION"
+            <cache-security container="$ctrl.container" data="$ctrl.data.security.SECURITY"
                             meta="$ctrl.getMetaForResource('authorization')"
                             init-defaults="$ctrl.initDefaults" read-only="$ctrl.readOnly"
                             config-callbacks="$ctrl.configCallbacks"/>

--- a/src/components/cache-configuration/view/replicated-cache.html
+++ b/src/components/cache-configuration/view/replicated-cache.html
@@ -45,7 +45,7 @@
         </uib-tab>
 
         <uib-tab heading="Security">
-            <cache-security container="$ctrl.container" data="$ctrl.data.security.SECURITY.authorization.AUTHORIZATION"
+            <cache-security container="$ctrl.container" data="$ctrl.data.security.SECURITY"
                             meta="$ctrl.getMetaForResource('authorization')"
                             init-defaults="$ctrl.initDefaults" read-only="$ctrl.readOnly"
                             config-callbacks="$ctrl.configCallbacks"/>

--- a/src/components/cache-security/view/cache-security.html
+++ b/src/components/cache-security/view/cache-security.html
@@ -16,10 +16,10 @@
 
                 </div>
                 <div class="form-horizontal" ng-if="$ctrl.isSecurityDefinedForContainer()">
-                    <form-group data="$ctrl.data" field="enabled" meta="$ctrl.meta['enabled']"
+                    <form-group data="$ctrl.auth" field="enabled" meta="$ctrl.meta['enabled']"
                                 previous-value="$ctrl.prevData['enabled']" read-only="$ctrl.readOnly"/>
                 </div>
-                <div class="form-horizontal" ng-if="$ctrl.data.enabled">
+                <div class="form-horizontal" ng-if="$ctrl.auth.enabled">
                     <div class="form-group">
                         <label class="col-md-4 control-label">Roles</label>
                         <div class="col-md-4">


### PR DESCRIPTION
…adds security tag to the configuration.

https://issues.jboss.org/browse/ISPN-7247


@vblagoje This prevents the <security> tags being added to a configuration when security isn't enabled and it allows config to be updated etc and the server restarted without errors. One problem at the minute though, is that if security is enabled for the container and a cache config is updated, then the following is added to the config:

```xml
<security>
    <authorization enabled="false" roles=""/>
</security>
```

^ Doesn't result in any errors (AFAIK), but it would cause an issue if the user disables container security in the xml and doesn't update their cache configs. Review and let me know what you think.