### PR TITLE
Cache-availability attribute does not exist for Local Caches.

### DIFF
--- a/src/services/cache/CacheService.ts
+++ b/src/services/cache/CacheService.ts
@@ -173,6 +173,9 @@ export class CacheService {
   }
 
   availability(container: ICacheContainer, cache: ICache): ng.IPromise<string> {
+    if (cache.isLocal()) {
+      return this.$q.resolve("AVAILABLE");
+    }
     let firstServer: IServerAddress = container.serverGroup.members[0];
     let address: string [] = this.generateHostServerAddress(firstServer, container, cache);
     let request: IDmrRequest = {


### PR DESCRIPTION

@vblagoje cache-availability attribute doesn't exist for local caches in either Standalone or Domain mode. My understanding is that if server containing the local cache is available, then the cache itself is AVAILABLE. Without this fix, it's not possible to resolve ISPN-7251 as I was not able to access the cache configuration screens due to the errors being thrown.