### PR TITLE
ISPN-7295 Cache container configuration does not work for non-clustered container

### DIFF
--- a/src/module/cache-container/config/ContainerConfig.ts
+++ b/src/module/cache-container/config/ContainerConfig.ts
@@ -22,7 +22,7 @@ module.config(($stateProvider: ng.ui.IStateProvider) => {
     templateUrl: "module/cache-container/config/view/config.html",
     controller: ContainerConfigCtrl,
     controllerAs: "ctrl",
-    redirectTo: "container-config.transport",
+    redirectTo: "container-config.thread-pools",
     resolve: {
       container: ["$stateParams", "containerService", ($stateParams, containerService) => {
         return containerService.getContainer($stateParams.containerName, $stateParams.profileName);


### PR DESCRIPTION
Master only. One more time this one @ryanemerson :-( Also resolves https://issues.jboss.org/browse/ISPN-7254 See https://issues.jboss.org/browse/ISPN-7295 for more details