### PR TITLE
ISPN-7330 Cannot edit configuration twice without refresh

### DIFF
--- a/src/module/cache-templates/CacheTemplatesCtrl.ts
+++ b/src/module/cache-templates/CacheTemplatesCtrl.ts
@@ -68,14 +68,23 @@ export class CacheTemplatesCtrl extends AbstractConfigurationCtrl {
       this.cacheConfigService.updateCacheConfiguration(this.container, this.template.type, this.template["template-name"], this.template)
         .then(() => {
             if (this.launchType.isStandaloneMode()) {
-              openConfirmationModal(this.$uibModal, "Config changes will only be made available after you manually restart the server!");
+              openConfirmationModal(this.$uibModal,
+                "Config changes will only be made available after you manually restart the server!").result.then(() => {
+                this.goToTemplateView();
+              }, ()=> {
+                this.goToTemplateView();
+              });
             } else {
-              openRestartModal(this.$uibModal).result.then(() => this.serverGroupService.restartServers(this.container.serverGroup));
+              openRestartModal(this.$uibModal).result.then(() => {
+                this.serverGroupService.restartServers(this.container.serverGroup).then(() => this.goToTemplateView())
+              }, () => {
+                this.goToTemplateView();
+              });
             }
             this.cleanMetaData();
           },
-          error => openErrorModal(this.$uibModal, error));
-    });
+          error => openErrorModal(this.$uibModal, error))
+    })
   }
 
   private reloadMetaAndDataOnTypeChange(newType: string, oldType: string): void {

--- a/src/module/cache/config/CacheConfigCtrl.ts
+++ b/src/module/cache/config/CacheConfigCtrl.ts
@@ -74,14 +74,23 @@ export class CacheConfigCtrl extends AbstractConfigurationCtrl {
       this.cacheConfigService.updateCacheConfiguration(this.container, this.template.type, this.template["template-name"], this.template)
         .then(() => {
             if (this.launchType.isStandaloneMode()) {
-              openConfirmationModal(this.$uibModal, "Config changes will only be made available after you manually restart the server!");
+              openConfirmationModal(this.$uibModal,
+                "Config changes will only be made available after you manually restart the server!").result.then(() => {
+                this.goToContainerCachesView();
+              }, ()=> {
+                this.goToContainerCachesView();
+              });
             } else {
-              openRestartModal(this.$uibModal).result.then(() => this.serverGroupService.restartServers(this.container.serverGroup));
+              openRestartModal(this.$uibModal).result.then(() => {
+                this.serverGroupService.restartServers(this.container.serverGroup).then(() => this.goToContainerCachesView())
+              }, () => {
+                this.goToContainerCachesView();
+              });
             }
             this.cleanMetaData();
           },
-          error => openErrorModal(this.$uibModal, error));
-    });
+          error => openErrorModal(this.$uibModal, error))
+    })
   }
 
   private reloadMetaAndDataOnTypeChange(newType: string, oldType: string): void {


### PR DESCRIPTION
Master only. @ryanemerson I will add "Server restarting dialog" as well a bit later. But for now, I think this is an appropriate solution for ISPN-7330 Please review and comment. Thank you