### PR TITLE
ISPN-7348: Cannot create new cache with template containing backup si…

### DIFF
--- a/src/module/cache/config/CacheConfigCtrl.ts
+++ b/src/module/cache/config/CacheConfigCtrl.ts
@@ -1,7 +1,7 @@
 import {ICacheContainer} from "../../../services/container/ICacheContainer";
 import {CacheConfigService} from "../../../services/cache-config/CacheConfigService";
 import {IStateService} from "angular-ui-router";
-import {isNotNullOrUndefined, isNonEmptyString} from "../../../common/utils/Utils";
+import {isNotNullOrUndefined, isNonEmptyString, setIsNewNodeRecursively} from "../../../common/utils/Utils";
 import {openErrorModal, openRestartModal, openConfirmationModal} from "../../../common/dialogs/Modals";
 import {AbstractConfigurationCtrl} from "../../../common/configuration/AbstractConfigurationCtrl";
 import {CacheService} from "../../../services/cache/CacheService";
@@ -43,6 +43,10 @@ export class CacheConfigCtrl extends AbstractConfigurationCtrl {
         }
       }
     });
+
+    if (!this.isEditMode()) {
+      setIsNewNodeRecursively(this.template);
+    }
   }
 
   goToContainerCachesView(): void {

--- a/src/services/cache-config/CacheConfigService.ts
+++ b/src/services/cache-config/CacheConfigService.ts
@@ -296,7 +296,7 @@ export class CacheConfigService {
         this.createHelper(builder, address.concat("partition-handling", "PARTITION_HANDLING"), config["partition-handling"]);
         this.createHelper(builder, address.concat("transaction", "TRANSACTION"), config.transaction);
         this.createHelper(builder, address.concat("state-transfer", "STATE_TRANSFER"), config["state-transfer"]);
-        this.createHelper(builder, address.concat("backup", "BACKUP"), config.backup);
+        this.createBackupNodes(builder, address.concat("backup"), config.backup);
 
         if (this.isSecurityAuthorizationEnabled(config)) {
           this.updateSecurityAuthorization(config);
@@ -321,6 +321,18 @@ export class CacheConfigService {
         exclusionList.push("type");
       }
       this.addOperationsToBuilder(builder, address, config, exclusionList, true);
+    }
+  }
+
+  private createBackupNodes(builder: CompositeOpBuilder, address: string[], config: any): void {
+    if (isNotNullOrUndefined(config)) {
+      angular.forEach(config, (val, key) => {
+        let exclusionList: string[] = ["is-new-node", "store-type", "store-original-type", "is-dirty"];
+        this.addCompositeOperationsToBuilder(builder, address.concat(key), val, exclusionList, true);
+        if (isNotNullOrUndefined(val["state-transfer"])) {
+          this.createHelper(builder, address.concat(key, "state-transfer", "STATE_TRANSFER"), val["state-transfer"]);
+        }
+      }, this);
     }
   }
 
@@ -374,7 +386,6 @@ export class CacheConfigService {
     this.updateHelper(builder, address.concat("partition-handling", "PARTITION_HANDLING"), config["partition-handling"]);
     this.updateHelper(builder, address.concat("transaction", "TRANSACTION"), config.transaction);
     this.updateHelper(builder, address.concat("state-transfer", "STATE_TRANSFER"), config["state-transfer"]);
-    this.updateHelper(builder, address.concat("backup", "BACKUP"), config.backup);
 
     if (this.isSecurityAuthorizationDefinedAndDirty(config)) {
       this.updateSecurityAuthorization(config);


### PR DESCRIPTION
…tes.

https://issues.jboss.org/browse/ISPN-7348

@vblagoje I know we don't currently allow for the configuration of backup sites [ISPN-6529](https://issues.jboss.org/browse/ISPN-6529), however if we are creating a config from an existing template, it makes sense for that underlying template to be copied in full to the new cache config, even if the user cannot modify these values in the console itself. 