### PR TITLE
ISPN-7328 Cache statuses in cache container page behave randomly

### DIFF
--- a/src/module/cache-container/caches/view/caches.html
+++ b/src/module/cache-container/caches/view/caches.html
@@ -31,7 +31,11 @@
         title="View Cache Details">
         <div class="card-pf card-pf-accented card-pf-aggregate-status card-pf-with-action" vertilize>
           <h2 class="card-pf-title">
-            <span class="pficon" ng-class="cachesCtrl.isAvailable(cache) && cachesCtrl.isEnabled(cache)? 'pficon-ok' : 'pficon-warning-triangle-o'"></span>{{cache.name}}
+            <span class="pficon"
+                  ng-class="{'pficon-help':!cachesCtrl.isStatusAvailable(cache),
+                  'pficon-ok':cachesCtrl.isAvailableAndEnabled(cache),
+                  'pficon-warning-triangle-o':cachesCtrl.isStatusAvailable(cache) && !cachesCtrl.isAvailableAndEnabled(cache)}">
+            </span>{{cache.name}}
           </h2>
 
           <div class="card-pf-body">

--- a/src/services/cache/CacheService.ts
+++ b/src/services/cache/CacheService.ts
@@ -185,14 +185,6 @@ export class CacheService {
     return this.dmrService.readAttribute(request);
   }
 
-  isAvailable(container: ICacheContainer, cache: ICache): ng.IPromise<boolean> {
-    let deferred: ng.IDeferred<boolean> = this.$q.defer<boolean>();
-    this.availability(container, cache).then((response: string) => {
-      deferred.resolve(response === "AVAILABLE");
-    }, () => deferred.resolve(false));
-    return deferred.promise;
-  }
-
   setRebalance(container: ICacheContainer, cache: ICache, rebalance: boolean): ng.IPromise<any> {
     return this.jgroupsService.getServerGroupCoordinator(container.serverGroup).then((coord: IServerAddress) => {
       return this.dmrService.executePost({


### PR DESCRIPTION
Master only. See https://issues.jboss.org/browse/ISPN-7328 for more details. Fetching caches statuses in one swoop using composite DMR requests (avoids bombarding server with cache_count * 2 requests for rendering container page). @ryanemerson please review and integrate