### PR TITLE
ISPN-7443 Memory usage chart is not displayed

### DIFF
--- a/src/module/server-instance/view/server-instance.html
+++ b/src/module/server-instance/view/server-instance.html
@@ -109,7 +109,7 @@
             <div class="row">
               <div class="col-md-8" ng-show="ctrl.serverInstance.isRunning()">
                 <h4>Heap Memory Usage</h4>
-                <div id-generator="perf_metrics.chart"></div>
+                <div id="chart"></div>
               </div>
               <div class="col-md-8" ng-show="false">
                 <h4>Node is stopped</h4>


### PR DESCRIPTION
Master only. @ryanemerson this is a regression due to id generation that I overlooked. We have to hard code this chart id and can not generate it on the fly.