### PR TITLE
ISPN-7478: Enable the console to utilise Infinispan extension on Wild…

### DIFF
--- a/src/services/container/ContainerService.ts
+++ b/src/services/container/ContainerService.ts
@@ -16,6 +16,7 @@ import {SecurityService} from "../security/SecurityService";
 import {LaunchTypeService} from "../launchtype/LaunchTypeService";
 import {ICache} from "../cache/ICache";
 import {CompositeOpBuilder} from "../dmr/CompositeOpBuilder";
+import {isNonEmptyArray} from "../../common/utils/Utils";
 
 const module: ng.IModule = App.module("managementConsole.services.container", []);
 
@@ -41,7 +42,7 @@ export class ContainerService {
     let deferred: ng.IDeferred<ICacheContainer[]> = this.$q.defer<ICacheContainer[]>();
 
     this.profileService.getAllProfileNames()
-      .then((profiles) => {
+      .then(profiles => {
         let promises: ng.IPromise<ICacheContainer[]>[] = [];
         for (let profileName of profiles) {
           promises.push(this.getAllCacheContainersByProfile(profileName));
@@ -49,7 +50,7 @@ export class ContainerService {
         return this.$q.all(promises);
       })
       .then((containers: [ICacheContainer[]]) => {
-        let allContainers: ICacheContainer[] = containers.reduce((a, b) => a.concat(b));
+        let allContainers: ICacheContainer[] = isNonEmptyArray(containers) ? containers.reduce((a, b) => a.concat(b)) : [];
         deferred.resolve(allContainers);
       });
     return deferred.promise;

--- a/src/services/profile/ProfileService.ts
+++ b/src/services/profile/ProfileService.ts
@@ -5,6 +5,7 @@ import {IDmrRequest} from "../dmr/IDmrRequest";
 import IQService = angular.IQService;
 import {LaunchTypeService} from "../launchtype/LaunchTypeService";
 import {StandaloneService} from "../standalone/StandaloneService";
+import {isNotNullOrUndefined, deepGet} from "../../common/utils/Utils";
 
 const module: ng.IModule = App.module("managementConsole.services.profile", []);
 
@@ -35,12 +36,16 @@ export class ProfileService {
     let request: IDmrRequest = <IDmrRequest>{
       address: [],
       "child-type": "profile",
+      "recursive-depth": 1
     };
     let deferred: ng.IDeferred<string[]> = this.$q.defer<string[]>();
-    this.dmrService.readChildResources(request).then((response) => {
+    this.dmrService.readChildResources(request).then(response => {
       let profiles: string[] = [];
       for (let key in response) {
-        profiles.push(key);
+        let path: string = key + ".subsystem.datagrid-infinispan";
+        if (isNotNullOrUndefined(deepGet(response, path))) {
+          profiles.push(key);
+        }
       }
       deferred.resolve(profiles);
     });


### PR DESCRIPTION
…fly.

https://issues.jboss.org/browse/ISPN-7478

@vblagoje These changes are required so that we account for profiles that may not have the infinispan subsystem defined. This can happen when a user installs the infinispan extension onto a standalone wildfly instance. For testing, I don't think it is necessary for you to go through the hassle of deploying the infinispan extension on wildfly as I have already checked this. However, it is important that you ensure these changes don't break the console in normal operation. 