### PR TITLE
ISPN-7644 Loader tab allows invalid configuration to be set. (2)

### DIFF
--- a/src/components/cache-loaders/CacheLoadersCtrl.ts
+++ b/src/components/cache-loaders/CacheLoadersCtrl.ts
@@ -19,34 +19,6 @@ const CACHE_LOADERS: {class: string, label: string}[] = [
   {
     class: "",
     label: "Custom Loader"
-  },
-  {
-    class: "org.infinispan.persistence.jpa.JpaStore",
-    label: "JPA Store"
-  },
-  {
-    class: "org.infinispan.persistence.rocksdb.RocksDBStore",
-    label: "RocksDB Store"
-  },
-  {
-    class: "org.infinispan.persistence.remote.RemoteStore",
-    label: "Remote Store"
-  },
-  {
-    class: "org.infinispan.persistence.rest.RestStore",
-    label: "Rest Store"
-  },
-  {
-    class: "org.infinispan.persistence.file.SingleFileStore",
-    label: "Single File Store"
-  },
-  {
-    class: "org.infinispan.persistence.sifs.SoftIndexFileStore",
-    label: "Soft Index File Store"
-  },
-  {
-    class: "org.infinispan.persistence.jdbc.stringbased.JdbcStringBasedStore",
-    label: "String Based JDBC Store"
   }
 ];
 


### PR DESCRIPTION
-- Removed all of the loader options from the dropdown menu, except "No cache loader", "Cluster Loader" and "Custom Loader".
-- See https://issues.jboss.org/browse/ISPN-7644 for more details.

https://issues.jboss.org/browse/ISPN-7644