### PR TITLE
ISPN-7748 Going back to General status tab from Nodes tab loses cache context

### DIFF
--- a/src/module/cache/Cache.ts
+++ b/src/module/cache/Cache.ts
@@ -106,7 +106,7 @@ module.config(($stateProvider: ng.ui.IStateProvider) => {
 
   $stateProvider.state("caches-node-stats", {
     parent: "root",
-    url: "containers/:profileName/:containerName/nodes",
+    url: "containers/:profileName/:containerName/caches/:cacheType/:cacheName/nodes",
     templateUrl: "module/cache/view/nodes.html",
     controller: CacheNodesCtrl,
     controllerAs: "ctrl",
@@ -117,7 +117,7 @@ module.config(($stateProvider: ng.ui.IStateProvider) => {
         }],
       cache: ["$stateParams", "cacheService",
         ($stateParams, cacheService: CacheService) => {
-          return cacheService.getCache("default", "distributed-cache", $stateParams.containerName, $stateParams.profileName);
+          return cacheService.getCache($stateParams.cacheName, $stateParams.cacheType, $stateParams.containerName, $stateParams.profileName);
         }],
       allCacheStats: ["cacheService", "container", "cache",
         (cacheService: CacheService, container: ICacheContainer, cache: ICache) => {

--- a/src/module/cache/view/cache.html
+++ b/src/module/cache/view/cache.html
@@ -94,7 +94,7 @@
       <!--ul class="nav nav-tabs nav-tabs-pf"-->
       <ul class="nav nav-tabs nav-tabs">
         <li class="active"><a>General status</a></li>
-        <li ng-if="!ctrl.isLocalMode()"><a ui-sref="caches-node-stats({profileName: ctrl.container.profile, containerName: ctrl.container.name})">Nodes</a></li>
+        <li ng-if="!ctrl.isLocalMode()"><a ui-sref="caches-node-stats({profileName: ctrl.container.profile, containerName: ctrl.container.name, cacheName:ctrl.cache.name, cacheType: ctrl.cache.type})">Nodes</a></li>
       </ul>
     </div>
   </div>


### PR DESCRIPTION
Master and 9.0.x. See https://issues.jboss.org/browse/ISPN-7748 for more details