### PR TITLE
ISPN-8279 Console support for Off-Heap

### DIFF
--- a/src/common/utils/Utils.ts
+++ b/src/common/utils/Utils.ts
@@ -1,6 +1,12 @@
 import {IServerAddress} from "../../services/server/IServerAddress";
 import {ServerAddress} from "../../services/server/ServerAddress";
 
+export const enum MemoryUnits {
+  KB,
+  MB,
+  GB
+}
+
 export function isString(object: any): boolean {
   return isNotNullOrUndefined(object) && typeof object === "string";
 }
@@ -174,6 +180,29 @@ export function getInstanceFromDmr<T>(dmr: any): T {
     retObject[key] = dmr[key];
   }
   return retObject;
+}
+
+export function convertBytes(bytes: number, unit: MemoryUnits): string {
+  let result: string;
+  switch (+unit) {
+    case (MemoryUnits.KB):
+      result = round((bytes / 1024), 2) + " KB";
+      break;
+    case(MemoryUnits.MB):
+      result = round((bytes / 1024 / 1024), 2) + " MB";
+      break;
+    case (MemoryUnits.GB):
+      result = round((bytes / 1024 / 1024 / 1024), 2) + " GB";
+      break;
+    default:
+      break;
+  }
+  return result;
+}
+
+export function round(value: number, precision: number): number {
+  let multiplier: number = Math.pow(10, precision || 0);
+  return Math.round(value * multiplier) / multiplier;
 }
 
 export function capitalizeFirstLetter(s: string): string {

--- a/src/common/utils/Utils.ts
+++ b/src/common/utils/Utils.ts
@@ -1,12 +1,6 @@
 import {IServerAddress} from "../../services/server/IServerAddress";
 import {ServerAddress} from "../../services/server/ServerAddress";
 
-export const enum MemoryUnits {
-  KB,
-  MB,
-  GB
-}
-
 export function isString(object: any): boolean {
   return isNotNullOrUndefined(object) && typeof object === "string";
 }
@@ -182,27 +176,20 @@ export function getInstanceFromDmr<T>(dmr: any): T {
   return retObject;
 }
 
-export function convertBytes(bytes: number, unit: MemoryUnits): string {
-  let result: string;
-  switch (+unit) {
-    case (MemoryUnits.KB):
-      result = round((bytes / 1024), 2) + " KB";
-      break;
-    case(MemoryUnits.MB):
-      result = round((bytes / 1024 / 1024), 2) + " MB";
-      break;
-    case (MemoryUnits.GB):
-      result = round((bytes / 1024 / 1024 / 1024), 2) + " GB";
-      break;
-    default:
-      break;
+export function convertBytes(bytes: number): string {
+  if (isNullOrUndefined(bytes) || bytes < 0) {
+    return "N/A"
   }
-  return result;
-}
-
-export function round(value: number, precision: number): number {
-  let multiplier: number = Math.pow(10, precision || 0);
-  return Math.round(value * multiplier) / multiplier;
+  else if (bytes === 0) {
+    return "0 Bytes";
+  } else {
+    let sizes: string [] = ["Bytes", "KB", "MB", "GB", "TB"];
+    let i: number = Number(Math.floor(Math.log(bytes) / Math.log(1024)));
+    if (i === 0) {
+      return bytes + " " + sizes[i];
+    }
+    return (bytes / Math.pow(1024, i)).toFixed(2) + " " + sizes[i];
+  }
 }
 
 export function capitalizeFirstLetter(s: string): string {

--- a/src/module/cache/Cache.ts
+++ b/src/module/cache/Cache.ts
@@ -26,9 +26,9 @@ module.config(($stateProvider: ng.ui.IStateProvider) => {
         ($stateParams, containerService: ContainerService) => {
           return containerService.getContainer($stateParams.containerName, $stateParams.profileName);
         }],
-      cache: ["$stateParams", "cacheService",
-        ($stateParams, cacheService: CacheService) => {
-          return cacheService.getCache($stateParams.cacheName, $stateParams.cacheType, $stateParams.containerName, $stateParams.profileName);
+      cache: ["$stateParams", "cacheService", "container",
+        ($stateParams, cacheService: CacheService, container: ICacheContainer) => {
+          return cacheService.getCacheWithConfiguration(container, $stateParams.cacheType, $stateParams.cacheName);
         }],
       stats: ["$stateParams", "container", "cache", "cacheService",
         ($stateParams, container: ICacheContainer, cache: ICache, cacheService: CacheService) => {

--- a/src/module/cache/Cache.ts
+++ b/src/module/cache/Cache.ts
@@ -115,9 +115,9 @@ module.config(($stateProvider: ng.ui.IStateProvider) => {
         ($stateParams, containerService: ContainerService) => {
           return containerService.getContainer($stateParams.containerName, $stateParams.profileName);
         }],
-      cache: ["$stateParams", "cacheService",
-        ($stateParams, cacheService: CacheService) => {
-          return cacheService.getCache($stateParams.cacheName, $stateParams.cacheType, $stateParams.containerName, $stateParams.profileName);
+      cache: ["$stateParams", "cacheService", "container",
+        ($stateParams, cacheService: CacheService, container: ICacheContainer) => {
+          return cacheService.getCacheWithConfiguration(container, $stateParams.cacheType, $stateParams.cacheName);
         }],
       allCacheStats: ["cacheService", "container", "cache",
         (cacheService: CacheService, container: ICacheContainer, cache: ICache) => {

--- a/src/module/cache/CacheCtrl.ts
+++ b/src/module/cache/CacheCtrl.ts
@@ -183,7 +183,7 @@ export class CacheCtrl {
   }
 
   convertBytes(bytes: number): string {
-    return convertBytes(bytes, this.launchType.getMemoryUnit());
+    return convertBytes(bytes);
   }
 
   private refresh(): void {

--- a/src/module/cache/CacheCtrl.ts
+++ b/src/module/cache/CacheCtrl.ts
@@ -178,6 +178,19 @@ export class CacheCtrl {
     }
   }
 
+  calculateMaxOffHeap(cache: ICache): number {
+    let size: number = cache.offHeapSize();
+    if (size > -1) {
+      return size * this.clusterSize();
+    } else {
+      return -1;
+    }
+  }
+
+  hasMaxOffHeapValue(cache: ICache): boolean {
+    return this.calculateMaxOffHeap(cache) > 0;
+  }
+
   private refresh(): void {
     this.cacheService.getCacheStats(this.container, this.cache).then((result) => {
       this.stats = result;

--- a/src/module/cache/CacheCtrl.ts
+++ b/src/module/cache/CacheCtrl.ts
@@ -7,7 +7,7 @@ import {ICache} from "../../services/cache/ICache";
 import IModalServiceInstance = angular.ui.bootstrap.IModalServiceInstance;
 import IModalService = angular.ui.bootstrap.IModalService;
 import {LaunchTypeService} from "../../services/launchtype/LaunchTypeService";
-import {isNullOrUndefined} from "../../common/utils/Utils";
+import {isNullOrUndefined, convertBytes} from "../../common/utils/Utils";
 
 export class CacheCtrl {
   static $inject: string[] = ["$state", "$interval", "$uibModal", "cacheService", "launchType",
@@ -180,6 +180,10 @@ export class CacheCtrl {
 
   hasMaxOffHeapValue(cache: ICache): boolean {
     return this.calculateMaxOffHeap(cache) > 0;
+  }
+
+  convertBytes(bytes: number): string {
+    return convertBytes(bytes, this.launchType.getMemoryUnit());
   }
 
   private refresh(): void {

--- a/src/module/cache/CacheCtrl.ts
+++ b/src/module/cache/CacheCtrl.ts
@@ -7,8 +7,7 @@ import {ICache} from "../../services/cache/ICache";
 import IModalServiceInstance = angular.ui.bootstrap.IModalServiceInstance;
 import IModalService = angular.ui.bootstrap.IModalService;
 import {LaunchTypeService} from "../../services/launchtype/LaunchTypeService";
-import {IServerGroup} from "../../services/server-group/IServerGroup";
-import {isNotNullOrUndefined} from "../../common/utils/Utils";
+import {isNullOrUndefined} from "../../common/utils/Utils";
 
 export class CacheCtrl {
   static $inject: string[] = ["$state", "$interval", "$uibModal", "cacheService", "launchType",
@@ -167,24 +166,16 @@ export class CacheCtrl {
   }
 
   clusterSize(): number {
-    if (this.isLocalMode()) {
+    if (this.isLocalMode() || isNullOrUndefined(this.container.serverGroup)) {
       return 1;
     } else {
-      if (isNotNullOrUndefined(this.container.serverGroup)) {
-        return this.container.serverGroup.members.length;
-      } else {
-        return 1;
-      }
+      return this.container.serverGroup.members.length;
     }
   }
 
   calculateMaxOffHeap(cache: ICache): number {
     let size: number = cache.offHeapSize();
-    if (size > -1) {
-      return size * this.clusterSize();
-    } else {
-      return -1;
-    }
+    return size > -1 ? size * this.clusterSize() : -1;
   }
 
   hasMaxOffHeapValue(cache: ICache): boolean {

--- a/src/module/cache/CacheCtrl.ts
+++ b/src/module/cache/CacheCtrl.ts
@@ -7,6 +7,8 @@ import {ICache} from "../../services/cache/ICache";
 import IModalServiceInstance = angular.ui.bootstrap.IModalServiceInstance;
 import IModalService = angular.ui.bootstrap.IModalService;
 import {LaunchTypeService} from "../../services/launchtype/LaunchTypeService";
+import {IServerGroup} from "../../services/server-group/IServerGroup";
+import {isNotNullOrUndefined} from "../../common/utils/Utils";
 
 export class CacheCtrl {
   static $inject: string[] = ["$state", "$interval", "$uibModal", "cacheService", "launchType",
@@ -162,6 +164,18 @@ export class CacheCtrl {
     this.cacheService.resetStats(this.container, this.cache).finally(() => {
       this.refresh();
     });
+  }
+
+  clusterSize(): number {
+    if (this.isLocalMode()) {
+      return 1;
+    } else {
+      if (isNotNullOrUndefined(this.container.serverGroup)) {
+        return this.container.serverGroup.members.length;
+      } else {
+        return 1;
+      }
+    }
   }
 
   private refresh(): void {

--- a/src/module/cache/CacheNodesCtrl.ts
+++ b/src/module/cache/CacheNodesCtrl.ts
@@ -2,13 +2,12 @@ import {ICacheContainer} from "../../services/container/ICacheContainer";
 import {ICache} from "../../services/cache/ICache";
 import {CacheService} from "../../services/cache/CacheService";
 import {IStateService} from "angular-ui-router";
-import {LaunchTypeService} from "../../services/launchtype/LaunchTypeService";
 import {convertBytes} from "../../common/utils/Utils";
 export class CacheNodesCtrl {
-  static $inject: string[] = ["$state", "cacheService", "container", "cache", "allCacheStats", "launchType"];
+  static $inject: string[] = ["$state", "cacheService", "container", "cache", "allCacheStats"];
 
   constructor(private $state: IStateService, private cacheService: CacheService, private container: ICacheContainer,
-              private cache: ICache, private allCacheStats: any[], private launchType: LaunchTypeService) {
+              private cache: ICache, private allCacheStats: any[]) {
   }
 
   currentCacheAvailability(): boolean {
@@ -20,7 +19,7 @@ export class CacheNodesCtrl {
   }
 
   convertBytes(bytes: number): string {
-    return convertBytes(bytes, this.launchType.getMemoryUnit());
+    return convertBytes(bytes);
   }
 
   resetStats(): void {

--- a/src/module/cache/CacheNodesCtrl.ts
+++ b/src/module/cache/CacheNodesCtrl.ts
@@ -2,11 +2,13 @@ import {ICacheContainer} from "../../services/container/ICacheContainer";
 import {ICache} from "../../services/cache/ICache";
 import {CacheService} from "../../services/cache/CacheService";
 import {IStateService} from "angular-ui-router";
+import {LaunchTypeService} from "../../services/launchtype/LaunchTypeService";
+import {convertBytes} from "../../common/utils/Utils";
 export class CacheNodesCtrl {
-  static $inject: string[] = ["$state", "cacheService", "container", "cache", "allCacheStats"];
+  static $inject: string[] = ["$state", "cacheService", "container", "cache", "allCacheStats", "launchType"];
 
-  constructor(private $state:IStateService, private cacheService: CacheService, private container:ICacheContainer,
-              private cache:ICache, private allCacheStats: any[]) {
+  constructor(private $state: IStateService, private cacheService: CacheService, private container: ICacheContainer,
+              private cache: ICache, private allCacheStats: any[], private launchType: LaunchTypeService) {
   }
 
   currentCacheAvailability(): boolean {
@@ -15,6 +17,10 @@ export class CacheNodesCtrl {
 
   currentClusterAvailabilityAsString(): string {
     return this.container.available ? "AVAILABLE" : "N/A";
+  }
+
+  convertBytes(bytes: number): string {
+    return convertBytes(bytes, this.launchType.getMemoryUnit());
   }
 
   resetStats(): void {

--- a/src/module/cache/view/cache.html
+++ b/src/module/cache/view/cache.html
@@ -371,7 +371,37 @@
           </div>
         </div>
       </div>
+      </div>
+    <!-- END CARD -->
+
+    <div class="row row-cards-pf" vertilize-container>
+
+      <!-- BEGIN CARD -->
+      <div class="col-xs-6 col-sm-4 col-md-3" id-generator="locking" ng-if="ctrl.cache.hasOffHeapMemory()">
+        <div class="card-pf card-pf-accented ispn-card ispn-card" vertilize>
+          <div class="card-pf-heading">
+            <h2 class="card-pf-title">Off-Heap Memory</h2>
+          </div>
+          <div class="card-pf-body">
+            <div class="row">
+              <div class="col-md-12">
+                <table class="col-md-12">
+                  <tr>
+                    <th>Used</th>
+                    <td id-generator="cache_content.off_heap_used">{{(ctrl.stats[preappend + 'off-heap-memory-used']/1024/1024) | number}} MB</td>
+                  </tr>
+                  <tr ng-if="ctrl.cache.isOffHeapEvictionTypeMemory()">
+                    <th>Max</th>
+                    <td id-generator="cache_content.off_heap_max">{{((ctrl.cache.offHeapSize() * ctrl.clusterSize())/1024/1024) | number}} MB</td>
+                  </tr>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
       <!-- END CARD -->
+
     </div>
   </div>
 </div>

--- a/src/module/cache/view/cache.html
+++ b/src/module/cache/view/cache.html
@@ -392,7 +392,8 @@
                   </tr>
                   <tr ng-if="ctrl.cache.isOffHeapEvictionTypeMemory()">
                     <th>Max</th>
-                    <td id-generator="cache_content.off_heap_max">{{((ctrl.cache.offHeapSize() * ctrl.clusterSize())/1024/1024) | number}} MB</td>
+                    <td ng-if="ctrl.hasMaxOffHeapValue(ctrl.cache)" id-generator="cache_content.off_heap_max">{{((ctrl.calculateMaxOffHeap(ctrl.cache))/1024/1024) | number}} MB</td>
+                    <td ng-if="!ctrl.hasMaxOffHeapValue(ctrl.cache)" id-generator="cache_content.off_heap_max">N/A</td>
                   </tr>
                 </table>
               </div>

--- a/src/module/cache/view/cache.html
+++ b/src/module/cache/view/cache.html
@@ -388,11 +388,11 @@
                 <table class="col-md-12">
                   <tr>
                     <th>Used</th>
-                    <td id-generator="cache_content.off_heap_used">{{(ctrl.stats[preappend + 'off-heap-memory-used']/1024/1024) | number}} MB</td>
+                    <td id-generator="cache_content.off_heap_used">{{(ctrl.convertBytes(ctrl.stats[preappend + 'off-heap-memory-used']))}}</td>
                   </tr>
                   <tr ng-if="ctrl.cache.isOffHeapEvictionTypeMemory()">
                     <th>Max</th>
-                    <td ng-if="ctrl.hasMaxOffHeapValue(ctrl.cache)" id-generator="cache_content.off_heap_max">{{((ctrl.calculateMaxOffHeap(ctrl.cache))/1024/1024) | number}} MB</td>
+                    <td ng-if="ctrl.hasMaxOffHeapValue(ctrl.cache)" id-generator="cache_content.off_heap_max">{{ctrl.convertBytes(ctrl.calculateMaxOffHeap(ctrl.cache))}}</td>
                     <td ng-if="!ctrl.hasMaxOffHeapValue(ctrl.cache)" id-generator="cache_content.off_heap_max">N/A</td>
                   </tr>
                 </table>

--- a/src/module/cache/view/nodes.html
+++ b/src/module/cache/view/nodes.html
@@ -59,6 +59,7 @@
         <th>Total reads</th>
         <th>Total failed reads</th>
         <th>Total writes</th>
+        <th>Off-Heap used</th>
       </tr></thead>
       <tbody>
         <tr ng-repeat="stats in ctrl.allCacheStats">
@@ -69,6 +70,7 @@
           <td class="TotalReads">{{(stats['hits'] + stats['misses'])| number}}</td>
           <td class="TotalFailedReads">{{stats['misses'] | number}}</td>
           <td class="TotalWrites">{{stats['stores'] | number}}</td>
+          <td class="OffHeap">{{(stats['off-heap-memory-used'])/1024/1024 | number}}</td>
         </tr>
       </tbody></table>
   </div>

--- a/src/module/cache/view/nodes.html
+++ b/src/module/cache/view/nodes.html
@@ -59,7 +59,7 @@
         <th>Total reads</th>
         <th>Total failed reads</th>
         <th>Total writes</th>
-        <th>Off-Heap used</th>
+        <th ng-if="ctrl.cache.isOffHeapEvictionTypeMemory()">Off-Heap used</th>
       </tr></thead>
       <tbody>
         <tr ng-repeat="stats in ctrl.allCacheStats">
@@ -70,7 +70,7 @@
           <td class="TotalReads">{{(stats['hits'] + stats['misses'])| number}}</td>
           <td class="TotalFailedReads">{{stats['misses'] | number}}</td>
           <td class="TotalWrites">{{stats['stores'] | number}}</td>
-          <td class="OffHeap">{{(stats['off-heap-memory-used'])/1024/1024 | number}}</td>
+          <td ng-if="ctrl.cache.isOffHeapEvictionTypeMemory()" class="OffHeap">{{(stats['off-heap-memory-used'])/1024/1024 | number}}</td>
         </tr>
       </tbody></table>
   </div>

--- a/src/module/cache/view/nodes.html
+++ b/src/module/cache/view/nodes.html
@@ -70,7 +70,7 @@
           <td class="TotalReads">{{(stats['hits'] + stats['misses'])| number}}</td>
           <td class="TotalFailedReads">{{stats['misses'] | number}}</td>
           <td class="TotalWrites">{{stats['stores'] | number}}</td>
-          <td ng-if="ctrl.cache.isOffHeapEvictionTypeMemory()" class="OffHeap">{{(stats['off-heap-memory-used'])/1024/1024 | number}}</td>
+          <td ng-if="ctrl.cache.isOffHeapEvictionTypeMemory()" class="OffHeap">{{ctrl.convertBytes(stats['off-heap-memory-used'])}}</td>
         </tr>
       </tbody></table>
   </div>

--- a/src/module/server-instance/ServerInstanceCtrl.ts
+++ b/src/module/server-instance/ServerInstanceCtrl.ts
@@ -1,4 +1,4 @@
-import {deepGet, capitalizeFirstLetter} from "../../common/utils/Utils";
+import {deepGet, capitalizeFirstLetter, convertBytes} from "../../common/utils/Utils";
 import {openConfirmationModal} from "../../common/dialogs/Modals";
 import {ServerService} from "../../services/server/ServerService";
 import {IServerAddress} from "../../services/server/IServerAddress";
@@ -94,6 +94,10 @@ export class ServerInstanceCtrl {
         break;
       }
     });
+  }
+
+  convertBytes(bytes: number): string {
+    return convertBytes(bytes);
   }
 
   isCoordinator(): boolean {

--- a/src/module/server-instance/view/server-instance.html
+++ b/src/module/server-instance/view/server-instance.html
@@ -189,7 +189,7 @@
                     </div>
                   </div>
                 </div>
-                
+
                 <div class="row">
                   <div class="col-md-12">
                     <h4>Mapped Buffers</h4>
@@ -216,6 +216,29 @@
                   </div>
                 </div>
 
+              </div>
+            </div>
+            <div class="row">
+              <div class="col-md-4 memory-usage text-center" ng-show="ctrl.serverInstance.isRunning()">
+                <h4>Off-Heap Memory Usage</h4>
+              </div>
+
+              <div class="col-md-6 memory-info">
+                <div class="row memory-info">
+                  <div class="col-md-12">
+                    <h4>Memory</h4>
+                  </div>
+                  <div class="col-md-12">
+                    <div class="row">
+                      <div class="col-md-7">
+                        <span class="prop">Used</span>
+                      </div>
+                      <div class="col-md-5">
+                        <span id-generator="perf_metrics.thread.count">{{(ctrl.nodeStats['off-heap-memory-used']/1024/1024) | number}} MB</span>
+                      </div>
+                    </div>
+                  </div>
+                </div>
               </div>
             </div>
           </div>

--- a/src/module/server-instance/view/server-instance.html
+++ b/src/module/server-instance/view/server-instance.html
@@ -184,7 +184,7 @@
                         <span class="prop">Memory</span>
                       </div>
                       <div class="col-md-5">
-                        <span id-generator="perf_metrics.direct_buff.mem">{{(ctrl.directBufferPoolMemoryUsed/1024/1024)|number}} MB</span>
+                        <span id-generator="perf_metrics.direct_buff.mem">{{ctrl.convertBytes(ctrl.directBufferPoolMemoryUsed)}}</span>
                       </div>
                     </div>
                   </div>
@@ -210,7 +210,7 @@
                         <span class="prop">Memory</span>
                       </div>
                       <div class="col-md-5">
-                        <span id-generator="perf_metrics.mapped_buff.mem">{{(ctrl.mappedBufferPoolMemoryUsed/1024/1024)|number}} MB</span>
+                        <span id-generator="perf_metrics.mapped_buff.mem">{{ctrl.convertBytes(ctrl.mappedBufferPoolMemoryUsed)}}</span>
                       </div>
                     </div>
                   </div>
@@ -234,7 +234,7 @@
                         <span class="prop">Used</span>
                       </div>
                       <div class="col-md-5">
-                        <span id-generator="perf_metrics.thread.count">{{(ctrl.nodeStats['off-heap-memory-used']/1024/1024) | number}} MB</span>
+                        <span id-generator="perf_metrics.thread.count">{{ctrl.convertBytes(ctrl.nodeStats['off-heap-memory-used'])}}</span>
                       </div>
                     </div>
                   </div>

--- a/src/services/cache-config/ICacheConfiguration.ts
+++ b/src/services/cache-config/ICacheConfiguration.ts
@@ -7,6 +7,7 @@ export interface ICacheConfiguration {
   mode: string;
   module: string;
   owners: number;
+  memory: any;
   "remote-cache": string;
   "remote-site": string;
   "remote-timeout": number;

--- a/src/services/cache/Cache.ts
+++ b/src/services/cache/Cache.ts
@@ -58,4 +58,22 @@ export class Cache implements ICache {
   hasRemoteBackup(): boolean {
     return isNotNullOrUndefined(this.configModel) && isNotNullOrUndefined(this.configModel.backup);
   }
+
+  hasOffHeapMemory(): boolean {
+    return isNotNullOrUndefined(this.configModel) && isNotNullOrUndefined(this.configModel.memory)
+      && isNotNullOrUndefined(this.configModel.memory['OFF-HEAP']);
+  }
+
+  offHeapSize(): number {
+    if (this.hasOffHeapMemory()) {
+      return this.configModel.memory['OFF-HEAP'].size;
+    } else {
+      return -1;
+    }
+  }
+
+  isOffHeapEvictionTypeMemory(): boolean {
+    return this.hasOffHeapMemory() && this.configModel.memory['OFF-HEAP'].eviction == "MEMORY";
+  }
+
 }

--- a/src/services/cache/Cache.ts
+++ b/src/services/cache/Cache.ts
@@ -61,19 +61,19 @@ export class Cache implements ICache {
 
   hasOffHeapMemory(): boolean {
     return isNotNullOrUndefined(this.configModel) && isNotNullOrUndefined(this.configModel.memory)
-      && isNotNullOrUndefined(this.configModel.memory['OFF-HEAP']);
+      && isNotNullOrUndefined(this.configModel.memory["OFF-HEAP"]);
   }
 
   offHeapSize(): number {
     if (this.hasOffHeapMemory()) {
-      return this.configModel.memory['OFF-HEAP'].size;
+      return this.configModel.memory["OFF-HEAP"].size;
     } else {
       return -1;
     }
   }
 
   isOffHeapEvictionTypeMemory(): boolean {
-    return this.hasOffHeapMemory() && this.configModel.memory['OFF-HEAP'].eviction == "MEMORY";
+    return this.hasOffHeapMemory() && this.configModel.memory["OFF-HEAP"].eviction === "MEMORY";
   }
 
 }

--- a/src/services/cache/CacheService.ts
+++ b/src/services/cache/CacheService.ts
@@ -72,7 +72,9 @@ export class CacheService {
     let request: IDmrRequest = {
       address: this.generateContainerAddress(container, profile).concat(type, name)
     };
-    this.dmrService.readResource(request).then((response) => deferred.resolve(new Cache(name, type, response.configuration)));
+    this.dmrService.readResource(request).then((response) => {
+      deferred.resolve(new Cache(name, type, response.configuration));
+    }, error => deferred.reject(error));
     return deferred.promise;
   }
 
@@ -87,7 +89,7 @@ export class CacheService {
         c.configModel = response;
         deferred.resolve(c);
       });
-    });
+    }, error => deferred.reject(error));
     return deferred.promise;
   }
 

--- a/src/services/cache/CacheService.ts
+++ b/src/services/cache/CacheService.ts
@@ -76,6 +76,21 @@ export class CacheService {
     return deferred.promise;
   }
 
+  getCacheWithConfiguration(container: ICacheContainer, type: string, name: string): ng.IPromise<ICache> {
+    let deferred: ng.IDeferred<ICache> = this.$q.defer<ICache>();
+    let request: IDmrRequest = {
+      address: this.generateContainerAddress(container.name, container.profile).concat(type, name),
+    };
+    this.dmrService.readResource(request).then((response) => {
+      let c: ICache = new Cache(name, type, response.configuration);
+      this.getCacheTemplate(container, type, name).then((response) => {
+        c.configModel = response;
+        deferred.resolve(c);
+      });
+    });
+    return deferred.promise;
+  }
+
   getCacheTemplate(container: ICacheContainer, type: string, name: string): ng.IPromise<any> {
     let deferred: ng.IDeferred<any> = this.$q.defer();
     this.getCache(name, type, container.name, container.profile)

--- a/src/services/cache/ICache.ts
+++ b/src/services/cache/ICache.ts
@@ -28,4 +28,10 @@ export interface ICache {
   hasCompatibility(): boolean;
 
   hasRemoteBackup(): boolean;
+
+  hasOffHeapMemory(): boolean;
+
+  offHeapSize(): number;
+
+  isOffHeapEvictionTypeMemory(): boolean;
 }

--- a/src/services/launchtype/LaunchTypeService.ts
+++ b/src/services/launchtype/LaunchTypeService.ts
@@ -1,5 +1,5 @@
 import {App} from "../../ManagementConsole";
-import {isNullOrUndefined, isNotNullOrUndefined, MemoryUnits} from "../../common/utils/Utils";
+import {isNullOrUndefined, isNotNullOrUndefined} from "../../common/utils/Utils";
 import ILocalStorageService = angular.local.storage.ILocalStorageService;
 import {IServerAddress} from "../server/IServerAddress";
 import {DmrService} from "../dmr/DmrService";
@@ -76,10 +76,6 @@ export class LaunchTypeService {
     } else if (this.isStandaloneMode()) {
       return [];
     }
-  }
-
-  getMemoryUnit(): MemoryUnits {
-    return MemoryUnits.MB;
   }
 
   private set(launchType: string, hasJgroupsSubsystem: boolean): void {

--- a/src/services/launchtype/LaunchTypeService.ts
+++ b/src/services/launchtype/LaunchTypeService.ts
@@ -1,5 +1,5 @@
 import {App} from "../../ManagementConsole";
-import {isNullOrUndefined, isNotNullOrUndefined} from "../../common/utils/Utils";
+import {isNullOrUndefined, isNotNullOrUndefined, MemoryUnits} from "../../common/utils/Utils";
 import ILocalStorageService = angular.local.storage.ILocalStorageService;
 import {IServerAddress} from "../server/IServerAddress";
 import {DmrService} from "../dmr/DmrService";
@@ -76,6 +76,10 @@ export class LaunchTypeService {
     } else if (this.isStandaloneMode()) {
       return [];
     }
+  }
+
+  getMemoryUnit(): MemoryUnits {
+    return MemoryUnits.MB;
   }
 
   private set(launchType: string, hasJgroupsSubsystem: boolean): void {


### PR DESCRIPTION
Master only. Preview of off-heap memory stats for both cache and container(server node). @ryanemerson in order to test this PR please create a cache configuration template with off-heap memory. Make sure to set type to "OFF-HEAP", eviction to "MEMORY" or "COUNT" and then create a cache C using this off heap template. Perhaps create one template with "MEMORY" and the other with "COUNT" eviction. Then go on cache C stats screen, you should see this:
![screen shot 2017-09-12 at 4 32 11 am](https://user-images.githubusercontent.com/458335/30315909-645cd408-9773-11e7-89a4-10559028173b.png)

Not the new card displaying stats for off heap memory usage. We are able to display max memory used only if we have "OFF-HEAP" with eviction set to "MEMORY". Otherwise, we only display off-heap memory used. Please check that "Off heap" card is not shown for other caches as well. Also please check that "Nodes" tab displays "Off heap memory used".

On single server page stats you should also find Off heap section. 
![screen shot 2017-09-12 at 4 35 03 am](https://user-images.githubusercontent.com/458335/30316028-d0b1e800-9773-11e7-9443-48a487bc01dd.png)

Here we do not have max off heap reading as it is a bit more complicated to calculate and it is not available in DMR. I left that part for later not to complicate things too much. 


