### PR TITLE
ISPN-8827 Disable browser cache for some resources in Admin Console

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 node
 node_modules
 dist
-!dist/index.html
 .idea
 .vscode
 .tmp

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "management-console",
-  "version": "9.0.0-SNAPSHOT",
+  "version": "9.2.0-SNAPSHOT",
   "license": "Apache-2.0",
   "dependencies": {
     "bootstrap": "3.3.7",
@@ -23,6 +23,8 @@
     "gulp-ng-annotate": "~2.0.0",
     "gulp-protractor": "~2.3.0",
     "gulp-size": "2.1.0",
+    "gulp-string-replace": "^1.0.0",
+    "gulp-rename": "^1.2.2",
     "gulp-tslint": "~5.0.0",
     "gulp-typedoc": "~2.0.0",
     "gulp-util": "3.0.7",

--- a/src/index_tmp.html
+++ b/src/index_tmp.html
@@ -12,7 +12,7 @@
   <ui-view name="main"></ui-view>
 </div>
 
-<script src="scripts/management-console.min.js"></script>
+<script src="scripts/management-console-@appVersion@.min.js"></script>
 
 </body>
 </html>

--- a/tasks/build-dist.js
+++ b/tasks/build-dist.js
@@ -1,11 +1,16 @@
 module.exports = (gulp, config) => () => {
   const path = require('path');
+  const replace = require('gulp-string-replace');
+  const rename = require("gulp-rename");
   const Builder = require('jspm').Builder;
   const builder = new Builder();
   const packageJson = require(path.join(config.projectDir, 'package.json'));
+  const appName = packageJson.name;
+  const version = packageJson.version;
+  const fileName = appName.concat(version);
 
   return beginBuild()
-    .then(buildSFX)
+    .then(buildSFX).then(changeIndexJsVersion)
     .catch((err) => {
       console.log('\n\tBuild Failed\n', err);
       process.exit(1);
@@ -18,7 +23,9 @@ module.exports = (gulp, config) => () => {
 
   function buildSFX() {
     const appName = packageJson.name;
-    const distFileName = `${appName}.min.js`;
+    const version = packageJson.version;
+    const fileName = appName.concat('-').concat(version);
+    const distFileName = `${fileName}.min.js`;
     const outFile = path.join(config.scriptsDir, distFileName);
     const moduleName = config.moduleName;
     const buildConfig = {
@@ -28,4 +35,12 @@ module.exports = (gulp, config) => () => {
     };
     return builder.buildStatic(moduleName, outFile, buildConfig);
   }
+
+  function changeIndexJsVersion() {
+    return gulp.src(path.join(config.srcDir, 'index_tmp.html'))
+      .pipe(rename('index.html'))
+      .pipe(replace(new RegExp('@appVersion@', 'g'), version))
+      .pipe(gulp.dest(config.distDir));
+  }
+
 };

--- a/tasks/clean.js
+++ b/tasks/clean.js
@@ -13,8 +13,7 @@ module.exports = (gulp, dir, config, cleanAll) => () => {
 
   var cleanDist = function (directory) {
     return del([
-      path.join(directory, '**', '*'),
-      '!' + path.join(directory, 'index.html')
+      path.join(directory, '**', '*')
     ]);
   };
 

--- a/tasks/html.js
+++ b/tasks/html.js
@@ -1,7 +1,7 @@
 module.exports = (gulp, config) => () => {
   const path = require('path');
 
-  return gulp.src([path.join(config.srcDir, '/**/*.html'), '!src/index.html'])
+  return gulp.src([path.join(config.srcDir, '/**/*.html'), '!src/index.html', '!src/index_tmp.html'])
       .pipe(gulp.dest(config.distDir));
 
 };


### PR DESCRIPTION
Master and preview only. Please have a look, particularly about dist/index.html file as during every build we'll have that file dirty due to string replacement. We could move index.html to index_tmp.html, keep it versioned, and then during build make index.html and gitignore it.