### PR TITLE
Improving UX when user wants delete memory configuration

### DIFF
--- a/src/components/memory/MemoryCtrl.ts
+++ b/src/components/memory/MemoryCtrl.ts
@@ -6,6 +6,8 @@ import {
   makeFieldClean,
   makeFieldDirty
 } from "../../common/configuration/ConfigUtil";
+import {IModalService} from "angular-ui-bootstrap";
+import {openConfirmationModal} from "../../common/dialogs/Modals";
 
 export const MEMORY_TYPES: string [] = [ "BINARY", "OBJECT", "OFF-HEAP"];
 
@@ -25,7 +27,7 @@ export class MemoryCtrl implements IConfigurationCallback {
   loadedWithData: boolean = false;
   createdOrDestroyedFromUI: boolean = false;
 
-  constructor() {
+  constructor(private $scope: ng.IScope, private $uibModal: IModalService) {
     this.fields.length = 0;
     this.memoryTypes = MEMORY_TYPES;
     if (isNotNullOrUndefined(this.configCallbacks)) {
@@ -75,12 +77,18 @@ export class MemoryCtrl implements IConfigurationCallback {
   }
 
   destroy(): void {
-    delete this.data[this.type];
-    this.data["is-new-node"] = !this.loadedWithData;
-    this.fields.length = 0;
-    this.allfields.length = 0;
-    this.cleanMetadata();
-    this.createdOrDestroyedFromUI = true;
+
+    openConfirmationModal(this.$uibModal, "Are you sure you want delete this configuration?").result.then(() => {
+      delete this.data[this.type];
+      this.data["is-new-node"] = !this.loadedWithData;
+      this.fields.length = 0;
+      this.allfields.length = 0;
+      this.cleanMetadata();
+      this.createdOrDestroyedFromUI = true;
+      this.$scope.$emit("updateTemplate");
+    });
+
+
   }
 
   iterateFields(callback: (attribute: string) => void): void {

--- a/src/module/cache/config/CacheConfigCtrl.ts
+++ b/src/module/cache/config/CacheConfigCtrl.ts
@@ -44,6 +44,8 @@ export class CacheConfigCtrl extends AbstractConfigurationCtrl {
       }
     });
 
+    this.$scope.$on("updateTemplate", ()=> this.updateTemplateWithoutModalAsk());
+
     if (!this.isEditMode()) {
       setIsNewNodeRecursively(this.template);
     }
@@ -73,28 +75,36 @@ export class CacheConfigCtrl extends AbstractConfigurationCtrl {
     });
   }
 
+  updateTemplateWithoutModalAsk() {
+    this.updateCacheConfiguration();
+  }
+
   updateTemplate(): void {
     openConfirmationModal(this.$uibModal, "Update configuration " + this.template["template-name"] + "?").result.then(() => {
-      this.cacheConfigService.updateCacheConfiguration(this.container, this.template.type, this.template["template-name"], this.template)
-        .then(() => {
-            if (this.launchType.isStandaloneMode()) {
-              openConfirmationModal(this.$uibModal,
-                "Config changes will only be made available after you manually restart the server!").result.then(() => {
-                this.goToContainerCachesView();
-              }, () => {
-                this.goToContainerCachesView();
-              });
-            } else {
-              openRestartModal(this.$uibModal).result.then(() => {
-                this.serverGroupService.restartServers(this.container.serverGroup).then(() => this.goToContainerCachesView());
-              }, () => {
-                this.goToContainerCachesView();
-              });
-            }
-            this.cleanMetaData();
-          },
-          error => openErrorModal(this.$uibModal, error));
-    });
+        this.updateCacheConfiguration();
+      });
+  }
+
+  private updateCacheConfiguration() {
+    this.cacheConfigService.updateCacheConfiguration(this.container, this.template.type, this.template["template-name"], this.template)
+      .then(() => {
+          if (this.launchType.isStandaloneMode()) {
+            openConfirmationModal(this.$uibModal,
+              "Config changes will only be made available after you manually restart the server!").result.then(() => {
+              this.goToContainerCachesView();
+            }, () => {
+              this.goToContainerCachesView();
+            });
+          } else {
+            openRestartModal(this.$uibModal).result.then(() => {
+              this.serverGroupService.restartServers(this.container.serverGroup).then(() => this.goToContainerCachesView());
+            }, () => {
+              this.goToContainerCachesView();
+            });
+          }
+          this.cleanMetaData();
+        },
+        error => openErrorModal(this.$uibModal, error));
   }
 
   private reloadMetaAndDataOnTypeChange(newType: string, oldType: string): void {


### PR DESCRIPTION
When user wants delete memory (or any other) configuration is a little bit confusing.
First of all, user may thing his configuration could be deleted immediately (no confirmation when you click at a button). Currently to delete user need click at delete icon and after that click on Apply changes (far from delete icon) 

Second user can think that configuration was already deleted just clicking at delete icon and go to another page (link) and when they return to memory configuration they realize that configuration wasn't deleted.

With this commit user is asked if they really want delete the configuration (image attached) and when they confirm the configuration will automatically update and user don't need to click on "Apply changes" button
![screen shot 2018-10-26 at 16 23 57](https://user-images.githubusercontent.com/1463004/47589257-01bb0180-d93f-11e8-85b2-4ec4fb0f74ca.png)
